### PR TITLE
Fix response interceptor and auth controller

### DIFF
--- a/packages/api-server/src/auth/auth.controller.ts
+++ b/packages/api-server/src/auth/auth.controller.ts
@@ -38,7 +38,7 @@ export class AuthController {
 
   @UseGuards(NaverAuthGuard)
   @ApiCreatedResponse({ description: 'User logged in!' })
-  @HttpCode(HttpStatus.CREATED)
+  @HttpCode(302)
   @Get('naver/callback')
   async naverCallback(
     @Req() req: Request,
@@ -53,7 +53,6 @@ export class AuthController {
       return res
         .cookie('access_token', accessToken)
         .cookie('refresh_token', refreshToken)
-        .status(HttpStatus.CREATED)
         .redirect('http://localhost:3000/');
     } catch (e) {
       console.log(e);
@@ -63,7 +62,7 @@ export class AuthController {
 
   @UseGuards(GoogleAuthGuard)
   @ApiCreatedResponse({ description: 'User logged in!' })
-  @HttpCode(HttpStatus.CREATED)
+  @HttpCode(302)
   @Get('google/callback')
   async googleCallback(
     @Req() req: Request,
@@ -78,7 +77,6 @@ export class AuthController {
       return res
         .cookie('access_token', accessToken)
         .cookie('refresh_token', refreshToken)
-        .status(HttpStatus.CREATED)
         .redirect('http://localhost:3000/');
     } catch (e) {
       throw new InternalServerErrorException('Server Error', e);
@@ -87,7 +85,7 @@ export class AuthController {
 
   @UseGuards(KakaoAuthGuard)
   @ApiCreatedResponse({ description: 'User logged in!' })
-  @HttpCode(HttpStatus.CREATED)
+  @HttpCode(302)
   @Get('kakao/callback')
   async kakaoCallback(
     @Req() req: Request,
@@ -102,7 +100,6 @@ export class AuthController {
       return res
         .cookie('access_token', accessToken)
         .cookie('refresh_token', refreshToken)
-        .status(HttpStatus.CREATED)
         .redirect('http://localhost:3000/');
     } catch (e) {
       console.log(e);

--- a/packages/api-server/src/interceptor/response.interceptor.ts
+++ b/packages/api-server/src/interceptor/response.interceptor.ts
@@ -1,9 +1,11 @@
 import {
   CallHandler,
   ExecutionContext,
+  HttpStatus,
   Injectable,
   NestInterceptor,
 } from '@nestjs/common';
+import { Response } from 'express';
 import { map, Observable } from 'rxjs';
 
 @Injectable()
@@ -12,6 +14,13 @@ export class ResponseInterceptor implements NestInterceptor {
     context: ExecutionContext,
     next: CallHandler<any>,
   ): Observable<any> | Promise<Observable<any>> {
+    const ctx = context.switchToHttp();
+    const response: Response = ctx.getResponse<Response>();
+
+    if (300 <= response.statusCode && response.statusCode <= 399) {
+      return next.handle();
+    }
+
     return next.handle().pipe(
       map((data) => ({
         success: true,


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
 - [버그 수정]


## ❗️ 관련 이슈 [#]

## 📄 개요
- res.redirect의 default status가 302라 맞춰줌
- 인터셉터 전에 redirect 할 경우 response를 두번 보내게 되어 에러 발생. redirect가 일어났을 경우는 interceptor가 동작하지 않도록 함

## 🔁 변경 사항
### 변경 내용을 적어주세요 (커밋 번호를 적어주세요)
- 왜, 어떻게 변경했는지 상세한 설명을 작성 (생략 가능)

## 📸 동작 화면 스크린샷

## 👀 기타 논의 사항
