### PR TITLE
feat: emphasize if pathname equals menu link

### DIFF
--- a/packages/front-end/app/dashboard/_components/Sidebar/SidebarMenu.tsx
+++ b/packages/front-end/app/dashboard/_components/Sidebar/SidebarMenu.tsx
@@ -1,7 +1,7 @@
 import { Paragraph } from "@/components/Text";
-import { css } from "@/styled-system/css";
+import { css, cx } from "@/styled-system/css";
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 
 interface ElementPropType {
   text: string;
@@ -14,14 +14,21 @@ function MenuElement({ text, href }: ElementPropType) {
   query.forEach((value, key) => {
     queryParams[key] = value;
   });
+  const pathname = usePathname();
   return (
     <ul
-      className={css({
-        "&:hover": {
-          bg: "gray.100",
-        },
-        borderRadius: "8px",
-      })}
+      className={cx(
+        css({
+          "&:hover": {
+            bg: "gray.100",
+          },
+          borderRadius: "8px",
+        }),
+        pathname === href &&
+          css({
+            bg: "rose.100",
+          })
+      )}
     >
       <li>
         <Link

--- a/packages/front-end/app/dashboard/_components/Sidebar/SidebarUser.tsx
+++ b/packages/front-end/app/dashboard/_components/Sidebar/SidebarUser.tsx
@@ -3,22 +3,34 @@ import { css } from "@/styled-system/css";
 import SidebarUserSwitch from "./SidebarUserSwitch";
 
 export default function SidebarUser() {
-
   return (
     <div>
       <Paragraph variant="sub3" className={css({ margin: "8px 0" })}>
-        유저
+        역할 전환
       </Paragraph>
       <div
         className={css({
           display: "flex",
           alignItems: "justify-between",
+          marginBottom: "3rem",
         })}
       >
         <SidebarUserSwitch />
       </div>
-      <div className={css({ padding: "1rem 0" })}>
-        <p>유저이름</p>
+      <Paragraph variant="sub3" className={css({ margin: "8px 0" })}>
+        내 정보
+      </Paragraph>
+      <div
+        className={css({
+          padding: "1rem 0.5rem",
+          borderRadius: "8px",
+          cursor:"pointer",
+          "&:hover": {
+            bg: "gray.200",
+          },
+        })}
+      >
+        <p>아이콘, 유저이름</p>
       </div>
     </div>
   );

--- a/packages/front-end/app/dashboard/_components/Sidebar/index.tsx
+++ b/packages/front-end/app/dashboard/_components/Sidebar/index.tsx
@@ -15,7 +15,7 @@ export default function Sidebar() {
         borderColor: "gray.200",
         display: "flex",
         flexDirection: "column",
-        padding: "0 1rem"
+        padding: "1rem"
       })}
     >
       <Heading variant="h4">캐치업</Heading>

--- a/packages/front-end/app/login/page.tsx
+++ b/packages/front-end/app/login/page.tsx
@@ -2,7 +2,8 @@
 
 import { css } from "@/styled-system/css";
 import LoginButton from "./_components/LoginButton";
-import { PROJECT_NAME } from "@/Config";
+import { PROJECT_NAME } from "@/const/Config";
+
 
 export default function Page() {
   return (


### PR DESCRIPTION
사이드바메뉴에서 현재 라우트와 메뉴의 이름이 같다면 강조효과

## 📍 PR 타입 (하나 이상 선택)
 - [기능 추가]

## ❗️ 관련 이슈 [#]
#87 
## 📄 개요
- 사이드바 메뉴에서 현재 보고 있는 페이지 메뉴에 강조효과를 줍니다

## 🔁 변경 사항
- usePathname hook을 이용해 현재 pathname과 href props를 비교
- 오로지 Pathnamer과 관계있는 로직이므로 query param과 독립적으로 동작

## 📸 동작 화면 스크린샷
![image](https://github.com/user-attachments/assets/5b6fd785-4603-462a-8bbc-90ed4bc419fd)

## 👀 기타 논의 사항
