### PR TITLE
92 userouter

### DIFF
--- a/packages/front-end/app/dashboard/_components/Sidebar/SidebarMenu.tsx
+++ b/packages/front-end/app/dashboard/_components/Sidebar/SidebarMenu.tsx
@@ -1,7 +1,7 @@
 import { Paragraph } from "@/components/Text";
+import { useRouter } from "@/hook/useRouter";
 import { css, cx } from "@/styled-system/css";
 import Link from "next/link";
-import { usePathname, useSearchParams } from "next/navigation";
 
 interface ElementPropType {
   text: string;
@@ -9,12 +9,7 @@ interface ElementPropType {
 }
 
 function MenuElement({ text, href }: ElementPropType) {
-  const query = useSearchParams();
-  const queryParams: { [key: string]: string } = {};
-  query.forEach((value, key) => {
-    queryParams[key] = value;
-  });
-  const pathname = usePathname();
+  const {queryObj,pathname} = useRouter();
   return (
     <ul
       className={cx(
@@ -32,7 +27,7 @@ function MenuElement({ text, href }: ElementPropType) {
     >
       <li>
         <Link
-          href={{ pathname: href, query: queryParams }}
+          href={{ pathname: href, query: queryObj }}
           className={css({
             width: "100%",
             padding: "8px 4px",

--- a/packages/front-end/app/dashboard/_components/Sidebar/SidebarUserSwitch.tsx
+++ b/packages/front-end/app/dashboard/_components/Sidebar/SidebarUserSwitch.tsx
@@ -1,38 +1,20 @@
 import Switch from "@/components/Switch";
+import { useRouter } from "@/hook/useRouter";
 import { css } from "@/styled-system/css";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { ChangeEvent, useState } from "react";
-
-function parsingQueryIter(query: IterableIterator<[string, string]>) {
-  const queryObj: { [key: string]: string } = {};
-  for (const [key, value] of query) {
-    queryObj[key] = value;
-  }
-  return queryObj;
-}
-
-function parsingQueryObj(pathname: string, query: { [key: string]: string }) {
-  // just construct dummy base url
-  const url = new URL(pathname, "http://example.com");
-  Object.keys(query).forEach((key) => {
-    url.searchParams.append(key, query[key]);
-  });
-  return `${url.pathname}${url.search}`;
-}
 
 export default function SidebarUserSwitch() {
   const router = useRouter();
-  const pathname = usePathname();
-  const queryParams = useSearchParams();
+
   const [isChecked, setIsChecked] = useState(
-    queryParams.get("role") === "tutor"
+    router.query.get("role") === "tutor"
   );
   const handleSwitchChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const queryObj = parsingQueryIter(queryParams.entries());
-    const newRole = queryParams.get("role") === "tutor" ? "student" : "tutor";
-    queryObj["role"] = newRole;
-    const href = parsingQueryObj(pathname, queryObj);
-    router.replace(href, { scroll: false });
+    const newRole = router.query.get("role") === "tutor" ? "student" : "tutor";
+    router.queryObj["role"] = newRole;
+    router.replace(router.getURLString(router.pathname, router.queryObj), {
+      scroll: false,
+    });
     setIsChecked(e.target.checked);
   };
   return (

--- a/packages/front-end/app/dashboard/_components/Sidebar/SidebarUserSwitch.tsx
+++ b/packages/front-end/app/dashboard/_components/Sidebar/SidebarUserSwitch.tsx
@@ -5,7 +5,6 @@ import { ChangeEvent, useState } from "react";
 
 export default function SidebarUserSwitch() {
   const router = useRouter();
-
   const [isChecked, setIsChecked] = useState(
     router.query.get("role") === "tutor"
   );

--- a/packages/front-end/app/login/page.tsx
+++ b/packages/front-end/app/login/page.tsx
@@ -2,12 +2,12 @@
 
 import { css } from "@/styled-system/css";
 import LoginButton from "./_components/LoginButton";
-import { PROJECT_NAME } from "@/const/Config";
-
+import { PROJECT_NAME } from "@/const/config";
 
 export default function Page() {
   return (
-      <div className={css({
+    <div
+      className={css({
         display: "flex",
         paddingBottom: "3em",
         width: "100vw",
@@ -16,44 +16,58 @@ export default function Page() {
         flexDirection: "column",
         alignItems: "center",
         justifyContent: "center",
-      })}>
-        <div className={css({
+      })}
+    >
+      <div
+        className={css({
           display: "flex",
           padding: "2em 0",
           width: "25em",
           flexDirection: "column",
           alignItems: "center",
           gap: "1em",
-        })}>
-          <div className={css({
+        })}
+      >
+        <div
+          className={css({
             color: "#ffffff",
             fontSize: "4.5em",
             fontWeight: "bold",
-          })}>{PROJECT_NAME}</div>
-          <div className={css({
+          })}
+        >
+          {PROJECT_NAME}
+        </div>
+        <div
+          className={css({
             color: "#ffffff",
             fontSize: "1.5em",
             fontWeight: "bold",
-          })}>로그인 / 회원가입
-          </div>
-          <hr className={css({
+          })}
+        >
+          로그인 / 회원가입
+        </div>
+        <hr
+          className={css({
             margin: "1em 0",
             width: "100%",
             borderWidth: "0.15em",
             borderRadius: "1em",
-            borderColor: "#ffffff"
-          })}/>
-        </div>
-        <div className={css({
+            borderColor: "#ffffff",
+          })}
+        />
+      </div>
+      <div
+        className={css({
           display: "flex",
           width: "25em",
           flexDirection: "column",
           gap: "1em",
-        })}>
-          <LoginButton providerEnum="GOOGLE"/>
-          <LoginButton providerEnum="NAVER"/>
-          <LoginButton providerEnum="KAKAO"/>
-        </div>
+        })}
+      >
+        <LoginButton providerEnum="GOOGLE" />
+        <LoginButton providerEnum="NAVER" />
+        <LoginButton providerEnum="KAKAO" />
       </div>
+    </div>
   );
 }

--- a/packages/front-end/hook/useRouter.tsx
+++ b/packages/front-end/hook/useRouter.tsx
@@ -1,0 +1,38 @@
+import { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
+import {
+  useRouter as _useRouter,
+  ReadonlyURLSearchParams,
+  usePathname,
+  useSearchParams,
+} from "next/navigation";
+
+export interface RouterInstance extends AppRouterInstance {
+  pathname: string;
+  query: ReadonlyURLSearchParams;
+  queryObj:Record<string,string>;
+  getURLString: (pathname: string, queryObj:Record<string,string>) => string;
+}
+
+export const useRouter = (): RouterInstance => {
+  const router = _useRouter();
+  const query = useSearchParams();
+  const pathname = usePathname();
+  const queryObj = Object.fromEntries(query);
+  const getURLString = (
+    pathname: string,
+    queryObj:Record<string,string>
+  ) => {
+    const url = new URL(pathname, "http://example.com");
+    Object.keys(queryObj).forEach((key) => {
+      url.searchParams.append(key, queryObj[key]);
+    });
+    return `${url.pathname}${url.search}`;
+  };
+  return {
+    ...router,
+    query,
+    pathname,
+    queryObj,
+    getURLString,
+  };
+};

--- a/packages/front-end/hook/useRouter.tsx
+++ b/packages/front-end/hook/useRouter.tsx
@@ -22,7 +22,7 @@ export const useRouter = (): RouterInstance => {
     pathname: string,
     queryObj:Record<string,string>
   ) => {
-    const url = new URL(pathname, "http://example.com");
+    const url = new URL(pathname, "http://example.com"); // just dummy url, not use
     Object.keys(queryObj).forEach((key) => {
       url.searchParams.append(key, queryObj[key]);
     });


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
 - [기능 추가]


## ❗️ 관련 이슈 [#]
#92 
## 📄 개요
- route관련 로직 작성시 불러오는 Hook이 많음(useSearchParams, usePathname, useRouter) 
- 이를 프로세싱하는 로직이 필요해(ReadonlyURLSearchParams -> object, string) 코드 가독성이 저하
- route관련 로직을 담당하는 하나의 hook을 통한 문제해결의 필요성

## 🔁 변경 사항
- 기존 next/navigation의 useRouter return type인 AppRouterInstance type에 추가적인 Property 추가
```
export interface RouterInstance extends AppRouterInstance {
  pathname: string;
  query: ReadonlyURLSearchParams;
  queryObj:Record<string,string>;
  getURLString: (pathname: string, queryObj:Record<string,string>) => string;
}
```
- custom useRouter에서 처리되므로 query와 pathname을 별도의 hook을 통해 불러올 필요가 없음
```
const query = useSearchParams();
 const pathname = usePathname();
```
- 프로세싱 로직을 custom useRouter 내부에 작성해 추후 컴포넌트에서 hook 사용시 가독성 증가
```
  const queryObj = Object.fromEntries(query);
  const getURLString = (
    pathname: string,
    queryObj:Record<string,string>
  ) => {
    const url = new URL(pathname, "http://example.com"); // just dummy url, not use
    Object.keys(queryObj).forEach((key) => {
      url.searchParams.append(key, queryObj[key]);
    });
    return `${url.pathname}${url.search}`;
  };
```
= 136fc1c62d9442eb9bbcb9a62f4016e9aa79ad73 : 코드의 양이 확 줄고 가독성을 높여진 것을 볼 수 있음
## 📸 동작 화면 스크린샷

## 👀 기타 논의 사항
- getURLString함수를 useRouter hook 내부에서만 사용하게 하고, 기존 router.replace와 router.push에 URL object를 넣어 가독성을 높일 방법이 존재할 것 같음
- 현재로서는 hostname이 다른 경우 해당 hook을 제대로 사용하지 못할 것임(pathname에 그대로 넣으면 되긴 하나, 그 의미가 퇴색됨)
