### PR TITLE
136 checkbox delete

### DIFF
--- a/packages/front-end/app/dashboard/(data)/drive/_components/FileTable.tsx
+++ b/packages/front-end/app/dashboard/(data)/drive/_components/FileTable.tsx
@@ -1,4 +1,8 @@
 import {
+  fileAreCheckedAtom,
+  fileIsTotalCheckedAtom,
+} from "@/client/CheckBoxAtom";
+import {
   TableBody,
   TableContainer,
   TableHead,
@@ -29,7 +33,12 @@ export default function FileTable() {
     },
   });
   const { isTotalChecked, setIsTotalChecked, setIsCheckedOne, isCheckedOne } =
-    useCheckBoxes<any, number>({ data: data, id: "id" });
+    useCheckBoxes<any, number>({
+      data: data,
+      id: "id",
+      areCheckedAtom: fileAreCheckedAtom,
+      isTotalCheckedAtom: fileIsTotalCheckedAtom,
+    });
 
   return (
     <TableContainer>

--- a/packages/front-end/app/dashboard/(data)/drive/_components/FileTable.tsx
+++ b/packages/front-end/app/dashboard/(data)/drive/_components/FileTable.tsx
@@ -17,5 +17,5 @@ export default function FileTable() {
     },
   });
 
-  return <></>;
+  return <>지금은 아무것도 없음</>;
 }

--- a/packages/front-end/app/dashboard/(data)/drive/_components/FileTable.tsx
+++ b/packages/front-end/app/dashboard/(data)/drive/_components/FileTable.tsx
@@ -1,7 +1,18 @@
+import {
+  TableBody,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Td,
+  Th,
+} from "@/components/Table";
 import { useCheckBoxes } from "@/hook/useCheckBoxes";
 import { useRouter } from "@/hook/useRouter";
+import { css } from "@/styled-system/css";
 import { apiClient } from "@/util/axios";
 import { useSuspenseQuery } from "@tanstack/react-query";
+import { formatDate } from "date-fns";
+import { ChangeEvent, Dispatch, SetStateAction } from "react";
 
 export default function FileTable() {
   const { queryObj } = useRouter();
@@ -17,12 +28,83 @@ export default function FileTable() {
       return data;
     },
   });
-  const {
-    isTotalChecked,
-    setIsTotalChecked,
-    setIsCheckedOne,
-    isCheckedOne,
-  } = useCheckBoxes<any, number>({ data: data, id: "id" });
+  const { isTotalChecked, setIsTotalChecked, setIsCheckedOne, isCheckedOne } =
+    useCheckBoxes<any, number>({ data: data, id: "id" });
 
-  return <>지금은 아무것도 없음</>;
+  return (
+    <TableContainer>
+      <colgroup>
+        <col width="45px" />
+        <col />
+        <col width="30%" />
+      </colgroup>
+      <Head
+        setIsTotalChecked={setIsTotalChecked}
+        isTotalChecked={isTotalChecked}
+      />
+      <TableBody>{/* add row component */}</TableBody>
+    </TableContainer>
+  );
+}
+
+function Head({
+  setIsTotalChecked,
+  isTotalChecked,
+}: {
+  setIsTotalChecked: Dispatch<SetStateAction<boolean>>;
+  isTotalChecked: boolean;
+}) {
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setIsTotalChecked(e.target.checked);
+  };
+  return (
+    <TableHead>
+      <TableRow>
+        <Th>
+          <input
+            type="checkbox"
+            onChange={handleChange}
+            checked={isTotalChecked}
+          />
+        </Th>
+        <Th>제목</Th>
+        <Th>참여 시간</Th>
+      </TableRow>
+    </TableHead>
+  );
+}
+
+function Row({
+  el,
+  setIsCheckedOne,
+  isCheckedOne,
+}: {
+  el: any;
+  setIsCheckedOne: (id: number, value: boolean) => void;
+  isCheckedOne: (id: number) => boolean;
+}) {
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setIsCheckedOne(el.fileId, e.target.checked);
+  };
+  return (
+    <TableRow
+      className={css({
+        "&:hover": {
+          bg: "rose.50",
+        },
+        cursor: "pointer",
+        transition: "background 0.2s",
+      })}
+    >
+      <Td>
+        <input
+          type="checkbox"
+          onChange={handleChange}
+          checked={isCheckedOne(el.sessionId)}
+        />
+      </Td>
+      <Td>{el.fileName}</Td>
+      <Td>{formatDate(el.createdAt, "yyyy-MM-dd")}</Td>
+    </TableRow>
+  );
 }

--- a/packages/front-end/app/dashboard/(data)/drive/_components/FileTable.tsx
+++ b/packages/front-end/app/dashboard/(data)/drive/_components/FileTable.tsx
@@ -1,3 +1,4 @@
+import { useCheckBoxes } from "@/hook/useCheckBoxes";
 import { useRouter } from "@/hook/useRouter";
 import { apiClient } from "@/util/axios";
 import { useSuspenseQuery } from "@tanstack/react-query";
@@ -16,6 +17,12 @@ export default function FileTable() {
       return data;
     },
   });
+  const {
+    isTotalChecked,
+    setIsTotalChecked,
+    setIsCheckedOne,
+    isCheckedOne,
+  } = useCheckBoxes<any, number>({ data: data, id: "id" });
 
   return <>지금은 아무것도 없음</>;
 }

--- a/packages/front-end/app/dashboard/(data)/drive/_components/FileTable.tsx
+++ b/packages/front-end/app/dashboard/(data)/drive/_components/FileTable.tsx
@@ -1,0 +1,21 @@
+import { useRouter } from "@/hook/useRouter";
+import { apiClient } from "@/util/axios";
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+export default function FileTable() {
+  const { queryObj } = useRouter();
+  if (!queryObj["role"]) {
+    queryObj["role"] = "participant";
+  }
+  const { data } = useSuspenseQuery({
+    queryKey: ["user", "sessions", queryObj["role"]],
+    queryFn: async () => {
+      const { data } = await apiClient.get<any[]>("/user/files", {
+        params: queryObj,
+      });
+      return data;
+    },
+  });
+
+  return <></>;
+}

--- a/packages/front-end/app/dashboard/(data)/drive/page.tsx
+++ b/packages/front-end/app/dashboard/(data)/drive/page.tsx
@@ -1,3 +1,11 @@
-export default function Page(){
-    return <>안녕</>
+"use client";
+
+import FileTable from "./_components/FileTable";
+
+export default function Page() {
+  return (
+    <>
+      <FileTable />
+    </>
+  );
 }

--- a/packages/front-end/app/dashboard/(data)/drive/page.tsx
+++ b/packages/front-end/app/dashboard/(data)/drive/page.tsx
@@ -5,6 +5,7 @@ import FileTable from "./_components/FileTable";
 export default function Page() {
   return (
     <>
+    
       <FileTable />
     </>
   );

--- a/packages/front-end/app/dashboard/(data)/drive/page.tsx
+++ b/packages/front-end/app/dashboard/(data)/drive/page.tsx
@@ -1,12 +1,17 @@
 "use client";
 
+import { Suspense } from "react";
 import FileTable from "./_components/FileTable";
+import { ErrorBoundary } from "react-error-boundary";
 
 export default function Page() {
   return (
     <>
-    
-      <FileTable />
+      <Suspense fallback={<h1>로딩...</h1>}>
+        <ErrorBoundary fallback={<h1>에러</h1>}>
+          <FileTable />
+        </ErrorBoundary>
+      </Suspense>
     </>
   );
 }

--- a/packages/front-end/app/dashboard/(data)/layout.tsx
+++ b/packages/front-end/app/dashboard/(data)/layout.tsx
@@ -8,7 +8,7 @@ interface PropType {
 
 export default function Layout({ children }: PropType) {
   return (
-    <div className={css({ flexGrow: 1 })}>
+    <div className={css({ flexGrow: 1,paddingX:"1rem" })}>
       <OptionHeader />
       {children}
     </div>

--- a/packages/front-end/app/dashboard/(data)/session/_components/SessionHeader.tsx
+++ b/packages/front-end/app/dashboard/(data)/session/_components/SessionHeader.tsx
@@ -1,13 +1,20 @@
+import { sessionAreCheckedAtom } from "@/client/CheckBoxAtom";
 import Button from "@/components/Button";
 import { Heading } from "@/components/Text";
 import { useRouter } from "@/hook/useRouter";
 import { css } from "@/styled-system/css";
+import { useAtom } from "jotai";
 
 export default function SessionHeader() {
   const { queryObj } = useRouter();
   if (!queryObj["role"]) {
     queryObj["role"] = "participant";
   }
+  const [areChecked, setAreChecked] = useAtom(sessionAreCheckedAtom);
+  const checkedData = areChecked.filter((e) => e.checked).map((e) => e.id);
+  const handleDeleteButtonClick = () => {
+    console.log({ checkedData });
+  };
   return (
     <div
       className={css({
@@ -28,7 +35,7 @@ export default function SessionHeader() {
             ? "새로운 세션 생성"
             : "새로운 세션 참가"}
         </Button>
-        <Button disabled>선택한 세션 삭제</Button>
+        <Button onClick={handleDeleteButtonClick}>선택한 세션 삭제</Button>
       </div>
     </div>
   );

--- a/packages/front-end/app/dashboard/(data)/session/_components/SessionHeader.tsx
+++ b/packages/front-end/app/dashboard/(data)/session/_components/SessionHeader.tsx
@@ -1,0 +1,35 @@
+import Button from "@/components/Button";
+import { Heading } from "@/components/Text";
+import { useRouter } from "@/hook/useRouter";
+import { css } from "@/styled-system/css";
+
+export default function SessionHeader() {
+  const { queryObj } = useRouter();
+  if (!queryObj["role"]) {
+    queryObj["role"] = "participant";
+  }
+  return (
+    <div
+      className={css({
+        padding: "1.5rem 0",
+        display: "flex",
+        alignItems: "flex-end",
+        justifyContent: "space-between",
+      })}
+    >
+      <Heading variant="h4">
+        {queryObj["role"] === "participant"
+          ? "내가 참가한 세션"
+          : "내가 진행한 세션"}
+      </Heading>
+      <div className={css({ display: "flex", gap: "1rem" })}>
+        <Button>
+          {queryObj["role"] === "participant"
+            ? "새로운 세션 생성"
+            : "새로운 세션 참가"}
+        </Button>
+        <Button disabled>선택한 세션 삭제</Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/front-end/app/dashboard/(data)/session/_components/SessionTable.tsx
+++ b/packages/front-end/app/dashboard/(data)/session/_components/SessionTable.tsx
@@ -100,6 +100,7 @@ function Row({
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     setIsCheckedOne(el.sessionId, e.target.checked);
   };
+  console.log(el);
   return (
     <TableRow
       className={css({
@@ -118,7 +119,7 @@ function Row({
         />
       </Td>
       <Td>{el.sessionName}</Td>
-      <Td>{formatDate(el.createdAt, "yyyy-MM-dd")}</Td>
+      <Td>{formatDate(el.createdAt, "yyyy-MM-dd-HH")}</Td>
     </TableRow>
   );
 }

--- a/packages/front-end/app/dashboard/(data)/session/_components/SessionTable.tsx
+++ b/packages/front-end/app/dashboard/(data)/session/_components/SessionTable.tsx
@@ -30,8 +30,6 @@ export default function SessionTable() {
     },
   });
   const {
-    areChecked,
-    setAreChecked,
     isTotalChecked,
     setIsTotalChecked,
     setIsCheckedOne,

--- a/packages/front-end/app/dashboard/(data)/session/_components/SessionTable.tsx
+++ b/packages/front-end/app/dashboard/(data)/session/_components/SessionTable.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/Table";
 import { useCheckBoxes } from "@/hook/useCheckBoxes";
 import { useRouter } from "@/hook/useRouter";
+import { Session } from "@/schema/backend.schema";
 import { css } from "@/styled-system/css";
 import { apiClient } from "@/util/axios";
 import { useSuspenseQuery } from "@tanstack/react-query";
@@ -22,7 +23,7 @@ export default function SessionTable() {
   const { data } = useSuspenseQuery({
     queryKey: ["user", "sessions", queryObj["role"]],
     queryFn: async () => {
-      const { data }: { data: any[] } = await apiClient.get("/user/sessions", {
+      const { data } = await apiClient.get<Session[]>("/user/sessions", {
         params: queryObj,
       });
       return data;
@@ -35,7 +36,7 @@ export default function SessionTable() {
     setIsTotalChecked,
     setIsCheckedOne,
     isCheckedOne,
-  } = useCheckBoxes<any, number>({ data: data, id: "id" });
+  } = useCheckBoxes<Session, number>({ data: data, id: "sessionId" });
 
   return (
     <TableContainer>
@@ -49,10 +50,10 @@ export default function SessionTable() {
         isTotalChecked={isTotalChecked}
       />
       <TableBody>
-        {data.map((e: any) => (
+        {data.map((e) => (
           <Row
             el={e}
-            key={e.id}
+            key={e.sessionId}
             isCheckedOne={isCheckedOne}
             setIsCheckedOne={setIsCheckedOne}
           />
@@ -94,12 +95,12 @@ function Row({
   setIsCheckedOne,
   isCheckedOne,
 }: {
-  el: any;
+  el: Session;
   setIsCheckedOne: (id: number, value: boolean) => void;
   isCheckedOne: (id: number) => boolean;
 }) {
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setIsCheckedOne(el.id, e.target.checked);
+    setIsCheckedOne(el.sessionId, e.target.checked);
   };
   return (
     <TableRow
@@ -115,11 +116,11 @@ function Row({
         <input
           type="checkbox"
           onChange={handleChange}
-          checked={isCheckedOne(el.id)}
+          checked={isCheckedOne(el.sessionId)}
         />
       </Td>
-      <Td>{el.displayName}</Td>
-      <Td>{formatDate(el.joinedAt, "yyyy-MM-dd")}</Td>
+      <Td>{el.sessionName}</Td>
+      <Td>{formatDate(el.createdAt, "yyyy-MM-dd")}</Td>
     </TableRow>
   );
 }

--- a/packages/front-end/app/dashboard/(data)/session/_components/SessionTable.tsx
+++ b/packages/front-end/app/dashboard/(data)/session/_components/SessionTable.tsx
@@ -1,4 +1,8 @@
 import {
+  sessionAreCheckedAtom,
+  sessionIsTotalCheckedAtom,
+} from "@/client/CheckBoxAtom";
+import {
   TableBody,
   TableContainer,
   TableHead,
@@ -29,12 +33,13 @@ export default function SessionTable() {
       return data;
     },
   });
-  const {
-    isTotalChecked,
-    setIsTotalChecked,
-    setIsCheckedOne,
-    isCheckedOne,
-  } = useCheckBoxes<Session, number>({ data: data, id: "sessionId" });
+  const { isTotalChecked, setIsTotalChecked, setIsCheckedOne, isCheckedOne } =
+    useCheckBoxes<Session, number>({
+      data: data,
+      id: "sessionId",
+      isTotalCheckedAtom: sessionIsTotalCheckedAtom,
+      areCheckedAtom: sessionAreCheckedAtom,
+    });
 
   return (
     <TableContainer>
@@ -100,7 +105,6 @@ function Row({
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     setIsCheckedOne(el.sessionId, e.target.checked);
   };
-  console.log(el);
   return (
     <TableRow
       className={css({

--- a/packages/front-end/app/dashboard/(data)/session/page.tsx
+++ b/packages/front-end/app/dashboard/(data)/session/page.tsx
@@ -3,10 +3,12 @@
 import { Suspense } from "react";
 import SessionTable from "./_components/SessionTable";
 import { ErrorBoundary } from "react-error-boundary";
+import SessionHeader from "./_components/SessionHeader";
 
 export default function Page() {
   return (
     <>
+     <SessionHeader/>
       <Suspense fallback={<h1>로딩...</h1>}>
         <ErrorBoundary fallback={<h1>에러</h1>}>
           <SessionTable />

--- a/packages/front-end/client/CheckBoxAtom.tsx
+++ b/packages/front-end/client/CheckBoxAtom.tsx
@@ -1,0 +1,8 @@
+import { CheckType } from "@/type/CheckType";
+import { atom } from "jotai";
+
+export const sessionIsTotalCheckedAtom = atom<boolean>(false);
+export const sessionAreCheckedAtom = atom<CheckType[]>([]);
+
+export const fileIsTotalCheckedAtom = atom<boolean>(false);
+export const fileAreCheckedAtom = atom<CheckType[]>([]);

--- a/packages/front-end/hook/useCheckBoxes.tsx
+++ b/packages/front-end/hook/useCheckBoxes.tsx
@@ -1,6 +1,8 @@
 import { Dispatch, SetStateAction, useEffect, useState } from "react";
 import { useRouter } from "./useRouter";
 import { CheckType } from "@/type/CheckType";
+import { PrimitiveAtom, useAtom } from "jotai";
+import { SetAtom } from "@/type/JotaiType";
 
 /**
  * Custom hook for managing checkboxes.
@@ -19,23 +21,27 @@ export function useCheckBoxes<T, K = number>({
   data,
   id,
   initValue = false,
+  isTotalCheckedAtom,
+  areCheckedAtom,
 }: {
   data: T[];
   id: keyof T;
   initValue?: boolean;
+  isTotalCheckedAtom: PrimitiveAtom<boolean>;
+  areCheckedAtom: PrimitiveAtom<CheckType<K>[]>;
 }): {
   areChecked: CheckType<K>[];
-  setAreChecked: Dispatch<SetStateAction<CheckType<K>[]>>;
+  setAreChecked: SetAtom<[SetStateAction<CheckType<K>[]>], void>;
   isTotalChecked: boolean;
-  setIsTotalChecked: Dispatch<SetStateAction<boolean>>;
+  setIsTotalChecked: SetAtom<[SetStateAction<boolean>], void>;
   setIsCheckedOne: (id: K, value: boolean) => void;
   isCheckedOne: (id: K) => boolean;
   getIsChecked: () => {
     id: K;
   }[];
 } {
-  const [areChecked, setAreChecked] = useState<CheckType<K>[]>([]);
-  const [isTotalChecked, setIsTotalChecked] = useState(initValue);
+  const [areChecked, setAreChecked] = useAtom(areCheckedAtom);
+  const [isTotalChecked, setIsTotalChecked] = useAtom(isTotalCheckedAtom);
   const { pathname, query } = useRouter();
   useEffect(() => {
     if (data) {

--- a/packages/front-end/hook/useCheckBoxes.tsx
+++ b/packages/front-end/hook/useCheckBoxes.tsx
@@ -1,11 +1,7 @@
 import { Dispatch, SetStateAction, useEffect, useState } from "react";
 import { useRouter } from "./useRouter";
+import { CheckType } from "@/type/CheckType";
 
-/**
- * Generic type representing a checkbox state.
- * @template K - The type of the id.
- */
-export type CheckType<K> = { id: K; checked: boolean };
 /**
  * Custom hook for managing checkboxes.
  *

--- a/packages/front-end/mocks/data/sessions.ts
+++ b/packages/front-end/mocks/data/sessions.ts
@@ -1,50 +1,52 @@
-export const sessionData: {
-  id: number;
-  sessionID: number;
-  userID: number;
-  displayName: string;
-  joinedAt: Date;
-}[] = [
+import { Session } from "@/schema/backend.schema";
+
+export const sessionData: Session[] = [
   {
-    id: 1,
-    sessionID: 1,
-    userID: 1,
-    displayName: "1234",
-    joinedAt: new Date(2024, 1, 1, 13, 0),
+    sessionId: 1,
+    sessionName: "1234",
+    hostId: 1,
+    createdAt: "2024-07-24T05:52:21.838Z",
+    updatedAt: "2024-07-24T05:52:21.838Z",
+    closedAt: "2024-07-24T05:52:21.838Z",
   },
   {
-    id: 2,
-    sessionID: 2,
-    userID: 2,
-    displayName: "4321",
-    joinedAt: new Date(2024, 1, 2, 13, 0),
+    sessionId: 2,
+    sessionName: "4321",
+    hostId: 2,
+    createdAt: "2024-07-24T05:52:21.838Z",
+    updatedAt: "2024-07-24T05:52:21.838Z",
+    closedAt: "2024-07-24T05:52:21.838Z",
   },
   {
-    id: 3,
-    sessionID: 3,
-    userID: 1,
-    displayName: "qwerty",
-    joinedAt: new Date(2024, 1, 3, 13, 0),
+    sessionId: 3,
+    sessionName: "qwerty",
+    hostId: 1,
+    createdAt: "2024-07-24T05:52:21.838Z",
+    updatedAt: "2024-07-24T05:52:21.838Z",
+    closedAt: "2024-07-24T05:52:21.838Z",
   },
   {
-    id: 4,
-    sessionID: 4,
-    userID: 2,
-    displayName: "asdf",
-    joinedAt: new Date(2024, 1, 4, 13, 0),
+    sessionId: 4,
+    sessionName: "foobar",
+    hostId: 1,
+    createdAt: "2024-07-24T05:52:21.838Z",
+    updatedAt: "2024-07-24T05:52:21.838Z",
+    closedAt: "2024-07-24T05:52:21.838Z",
   },
   {
-    id: 5,
-    sessionID: 5,
-    userID: 1,
-    displayName: "zzz",
-    joinedAt: new Date(2024, 1, 5, 13, 0),
+    sessionId: 5,
+    sessionName: "alicebob",
+    hostId: 2,
+    createdAt: "2024-07-24T05:52:21.838Z",
+    updatedAt: "2024-07-24T05:52:21.838Z",
+    closedAt: "2024-07-24T05:52:21.838Z",
   },
   {
-    id: 6,
-    sessionID: 6,
-    userID: 1,
-    displayName: "hahaha",
-    joinedAt: new Date(2024, 1, 6, 13, 0),
+    sessionId: 6,
+    sessionName: "02468",
+    hostId: 1,
+    createdAt: "2024-07-24T05:52:21.838Z",
+    updatedAt: "2024-07-24T05:52:21.838Z",
+    closedAt: "2024-07-24T05:52:21.838Z",
   },
 ];

--- a/packages/front-end/mocks/handlers.ts
+++ b/packages/front-end/mocks/handlers.ts
@@ -1,7 +1,12 @@
 import { HttpHandler } from "msw";
-import { tokenRefreshHandler, userSessionHandler } from "./handlers/user";
+import {
+  tokenRefreshHandler,
+  userFileHandler,
+  userSessionHandler,
+} from "./handlers/user";
 
-export const handlers:HttpHandler[] = [
-    userSessionHandler,
-    tokenRefreshHandler,
+export const handlers: HttpHandler[] = [
+  userSessionHandler,
+  userFileHandler,
+  tokenRefreshHandler,
 ];

--- a/packages/front-end/mocks/handlers/user.ts
+++ b/packages/front-end/mocks/handlers/user.ts
@@ -18,13 +18,27 @@ export const userSessionHandler = http.get(
       });
     }
     const data = sessionData.filter(
-      (e) => e.userID === (role === "host" ? 1 : 2)
+      (e) => e.hostId === (role === "host" ? 1 : 2)
     );
     if (data) {
       return HttpResponse.json(data);
     } else {
       return new HttpResponse(null, { status: 404, statusText: "not found" });
     }
+  }
+);
+
+export const userFileHandler = http.get(
+  `${process.env.NEXT_PUBLIC_API_SERVER}/user/files`,
+  async ({ request }) => {
+    const accessToken = request.headers.get("Authorization")?.split(" ")[1];
+    if (!accessToken || accessToken === "undefined") {
+      return new HttpResponse(null, {
+        status: 401,
+        statusText: "Authorization Error",
+      });
+    }
+    return new HttpResponse(null, { status: 200, statusText: "임시 성공" });
   }
 );
 

--- a/packages/front-end/mocks/handlers/user.ts
+++ b/packages/front-end/mocks/handlers/user.ts
@@ -38,7 +38,7 @@ export const userFileHandler = http.get(
         statusText: "Authorization Error",
       });
     }
-    return new HttpResponse(null, { status: 200, statusText: "임시 성공" });
+    return HttpResponse.json([1, 2, 3]);
   }
 );
 

--- a/packages/front-end/type/CheckType.ts
+++ b/packages/front-end/type/CheckType.ts
@@ -1,0 +1,5 @@
+/**
+ * Generic type representing a checkbox state.
+ * @template K - The type of the id in origin data.
+ */
+export type CheckType<K=number> = { id: K; checked: boolean };

--- a/packages/front-end/type/JotaiType.ts
+++ b/packages/front-end/type/JotaiType.ts
@@ -1,0 +1,1 @@
+export type SetAtom<Args extends unknown[], Result> = (...args: Args) => Result;


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가


## ❗️ 관련 이슈 [#]
#136 
## 📄 개요
- react local state를 활용한 체크박스 상태관리로 기능구현하기엔 어렵다느껴, 클라이언트 전역 상태 활용

## 🔁 변경 사항
### jotai type
```
export type SetAtom<Args extends unknown[], Result> = (...args: Args) => Result; 
``` 
- type-safety를 위해 jotai 내부 타입 직접 /type 디렉토리에 만듬, 라이브러리에 setAtom type이 export가 안돼있음 ([링크](https://github.com/pmndrs/jotai/blob/main/src/react/useAtom.ts))
- 단 atom의 타입 
``` 
WithInitialValue<T> 
``` 
는 사용하지 말라고 명시돼있음([링크](https://github.com/pmndrs/jotai/blob/main/src/vanilla/atom.ts#L26)) 따라서 atom의 타입
```
PrimitiveAtom<T> & WithInitialValue<T> 
```
는 export돼있는 PrimitiveAtom type만을 취했고 현재 문제는 없음
```
export type CheckType<K=number> = { id: K; checked: boolean }; 
``` 
- 해당 타입이 생각보다 자주쓰여 역시나 따로 /type 디렉토리에 만듬
### useCheckBoxes
```
export function useCheckBoxes<T, K = number>({
  data,
  id,
  initValue = false,
  isTotalCheckedAtom,
  areCheckedAtom,
}: {
  data: T[];
  id: keyof T;
  initValue?: boolean;
  isTotalCheckedAtom: PrimitiveAtom<boolean>;
  areCheckedAtom: PrimitiveAtom<CheckType<K>[]>;
}): {
  areChecked: CheckType<K>[];
  setAreChecked: SetAtom<[SetStateAction<CheckType<K>[]>], void>;
  isTotalChecked: boolean;
  setIsTotalChecked: SetAtom<[SetStateAction<boolean>], void>;
  setIsCheckedOne: (id: K, value: boolean) => void;
  isCheckedOne: (id: K) => boolean;
  getIsChecked: () => {
    id: K;
  }[];
}  
```
-  추가적으로 전체 체크를 관리하는 아톰, 각각 데이터배열의 체크를 관리하는 아톰을 받음(2개의 arg 추가)
타입을 jotai에 맞춰 바꾼 것 외에 로직은 동일함
- 해당 훅에 맞춰서 sessionTable과 fileTable에 args 추가
```
  const [areChecked, setAreChecked] = useAtom(sessionAreCheckedAtom);
  const checkedData = areChecked.filter((e) => e.checked).map((e) => e.id);
  const handleDeleteButtonClick = () => {
    console.log({ checkedData });
  };
```
- 지우기 버튼은 단순히 콘솔 로그만 찍음, 실제론 데이터가 mutate돼 바뀔 것이므로 setState 해주지 않음
## 📸 동작 화면 스크린샷

## 👀 기타 논의 사항
- 체크 데이터를 뽑아오는 것을 util에 작성해도 좋을 것 같음