### PR TITLE
138 modal container

### DIFF
--- a/packages/front-end/app/dashboard/(data)/session/_components/SessionTable.tsx
+++ b/packages/front-end/app/dashboard/(data)/session/_components/SessionTable.tsx
@@ -27,12 +27,14 @@ export default function SessionTable() {
   const { data } = useSuspenseQuery({
     queryKey: ["user", "sessions", queryObj["role"]],
     queryFn: async () => {
-      const { data } = await apiClient.get<Session[]>("/user/sessions", {
+      return await apiClient.get("/user/sessions/list", {
         params: queryObj,
       });
-      return data;
     },
-  });
+  }).data.data;
+
+  console.log(data);
+
   const { isTotalChecked, setIsTotalChecked, setIsCheckedOne, isCheckedOne } =
     useCheckBoxes<Session, number>({
       data: data,

--- a/packages/front-end/app/dashboard/@modal/default.tsx
+++ b/packages/front-end/app/dashboard/@modal/default.tsx
@@ -1,3 +1,3 @@
-export default function Default(){
-    return <></>
+export default function Default() {
+  return <></>;
 }

--- a/packages/front-end/app/dashboard/@modal/default.tsx
+++ b/packages/front-end/app/dashboard/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function Default(){
+    return <></>
+}

--- a/packages/front-end/app/dashboard/@modal/user-menu/page.tsx
+++ b/packages/front-end/app/dashboard/@modal/user-menu/page.tsx
@@ -1,0 +1,5 @@
+import ModalContainer from "@/components/ModalContainer";
+
+export default function Page() {
+  return <ModalContainer>오오</ModalContainer>;
+}

--- a/packages/front-end/app/dashboard/_components/Sidebar/SidebarMenu.tsx
+++ b/packages/front-end/app/dashboard/_components/Sidebar/SidebarMenu.tsx
@@ -19,6 +19,7 @@ function MenuElement({ text, href }: ElementPropType) {
             bg: "gray.100",
           },
           borderRadius: "8px",
+          transition:"background 0.2s",
         }),
         pathname === href &&
           css({

--- a/packages/front-end/app/dashboard/_components/Sidebar/SidebarUser.tsx
+++ b/packages/front-end/app/dashboard/_components/Sidebar/SidebarUser.tsx
@@ -8,8 +8,12 @@ export default function SidebarUser() {
   return (
     <>
       <SidebarMenuGroup>
-        <div
+        <Link
+          href="/dashboard/user-menu"
           className={css({
+            width: "100%",
+            height: "100%",
+            display: "block",
             padding: "0.8em",
             borderRadius: "8px",
             cursor: "pointer",
@@ -18,8 +22,8 @@ export default function SidebarUser() {
             },
           })}
         >
-          <Link href="/dashboard/user-menu">USER NAME [강의자]</Link>
-        </div>
+          USER NAME [강의자]
+        </Link>
       </SidebarMenuGroup>
       <SidebarMenuGroup>
         <SidebarUserSwitch />

--- a/packages/front-end/app/dashboard/_components/Sidebar/SidebarUser.tsx
+++ b/packages/front-end/app/dashboard/_components/Sidebar/SidebarUser.tsx
@@ -11,15 +11,14 @@ export default function SidebarUser() {
         <Link
           href="/dashboard/user-menu"
           className={css({
-            width: "100%",
-            height: "100%",
             display: "block",
             padding: "0.8em",
             borderRadius: "8px",
             cursor: "pointer",
             "&:hover": {
-              bg: "gray.200",
+              bg: "gray.100",
             },
+            transition: "background 0.2s",
           })}
         >
           USER NAME [강의자]

--- a/packages/front-end/app/dashboard/_components/Sidebar/SidebarUser.tsx
+++ b/packages/front-end/app/dashboard/_components/Sidebar/SidebarUser.tsx
@@ -2,20 +2,23 @@ import { Paragraph } from "@/components/Text";
 import { css } from "@/styled-system/css";
 import SidebarUserSwitch from "./SidebarUserSwitch";
 import SidebarMenuGroup from "./SidebarMenuGroup";
+import Link from "next/link";
 
 export default function SidebarUser() {
   return (
     <>
       <SidebarMenuGroup>
-        <div className={css({
-          padding: "0.8em",
-          borderRadius: "8px",
-          cursor: "pointer",
-          "&:hover": {
+        <div
+          className={css({
+            padding: "0.8em",
+            borderRadius: "8px",
+            cursor: "pointer",
+            "&:hover": {
               bg: "gray.200",
-          },
-        })}>
-          <p>USER NAME [강의자]</p>
+            },
+          })}
+        >
+          <Link href="/dashboard/user-menu">USER NAME [강의자]</Link>
         </div>
       </SidebarMenuGroup>
       <SidebarMenuGroup>

--- a/packages/front-end/app/dashboard/layout.tsx
+++ b/packages/front-end/app/dashboard/layout.tsx
@@ -4,13 +4,17 @@ import Sidebar from "./_components/Sidebar";
 
 interface PropType {
   children: ReactNode;
+  modal: ReactNode;
 }
 
-export default function Layout({ children }: PropType) {
+export default function Layout({ children, modal }: PropType) {
   return (
-    <main className={css({ display: "flex", height: "100vh" })}>
-      <Sidebar />
-      {children}
-    </main>
+    <>
+      <main className={css({ display: "flex", height: "100vh" })}>
+        <Sidebar />
+        {children}
+      </main>
+      {modal}
+    </>
   );
 }

--- a/packages/front-end/components/ModalContainer.tsx
+++ b/packages/front-end/components/ModalContainer.tsx
@@ -35,7 +35,7 @@ export default function ModalContainer({ children }: PropType) {
         zIndex: 100,
         width: "100vw",
         height: "100vh",
-        backgroundColor: "rgba(128, 128, 128, 0.5)",
+        backgroundColor: "rgba(64, 64, 64, 0.5)",
         display: "flex",
         justifyContent: "center",
         alignItems: "center",

--- a/packages/front-end/components/ModalContainer.tsx
+++ b/packages/front-end/components/ModalContainer.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useRouter } from "@/hook/useRouter";
+import { ReactNode, useEffect } from "react";
+
+interface PropType {
+  children: ReactNode;
+}
+
+export default function ModalContainer({ children }: PropType) {
+  const router = useRouter();
+  const handleKeyPress = (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      router.back();
+    }
+  };
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyPress);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyPress);
+    };
+  }, []);
+  return (
+    <dialog open>
+        안녕하세요
+        {children}
+    </dialog>
+  )
+}

--- a/packages/front-end/components/ModalContainer.tsx
+++ b/packages/front-end/components/ModalContainer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRouter } from "@/hook/useRouter";
+import { css } from "@/styled-system/css";
 import { ReactNode, useEffect } from "react";
 
 interface PropType {
@@ -21,10 +22,27 @@ export default function ModalContainer({ children }: PropType) {
       document.removeEventListener("keydown", handleKeyPress);
     };
   }, []);
+  const handleBackdropClick = () => {
+    router.back();
+  };
   return (
-    <dialog open>
-        안녕하세요
-        {children}
+    <dialog
+      open
+      className={css({
+        position: "fixed",
+        top: 0,
+        left: 0,
+        zIndex: 100,
+        width: "100vw",
+        height: "100vh",
+        backgroundColor: "rgba(128, 128, 128, 0.5)",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+      })}
+      onClick={handleBackdropClick}
+    >
+      {children}
     </dialog>
-  )
+  );
 }

--- a/packages/front-end/mocks/handlers.ts
+++ b/packages/front-end/mocks/handlers.ts
@@ -6,7 +6,7 @@ import {
 } from "./handlers/user";
 
 export const handlers: HttpHandler[] = [
-  userSessionHandler,
+  
   userFileHandler,
   tokenRefreshHandler,
 ];

--- a/packages/front-end/stories/switch.stories.tsx
+++ b/packages/front-end/stories/switch.stories.tsx
@@ -8,6 +8,23 @@ const meta = {
   parameters: {
     layout: "centered",
   },
+  argTypes: {
+    size: {
+      control: false,
+    },
+    checked: {
+      control: false,
+    },
+    onChange: {
+      control: false,
+    },
+    name: {
+      control: false,
+    },
+    id: {
+      control: false,
+    },
+  },
 } satisfies Meta<typeof Switch>;
 
 export default meta;


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가

## ❗️ 관련 이슈 [#]
#138 
## 📄 개요
- 추후 모달을 만들때 사용되는 공통 스타일 및 로직을 담은 Modal container
- 모달은 병렬 라우트와 라우트 인터셉트로 구현

## 🔁 변경 사항
### 변경 내용을 적어주세요 (커밋 번호를 적어주세요)
- Modal-Container컴포넌트로 모달의 공통로직을 쉽게 사용할 수 있게함
  - 배경은 투명도가 있는 짙은 회색
  - 배경을 누르면 닫기
  - esc를 누르면 닫기
  - 뒤로가기 키 누르면 닫기
- overlay toolkit라이브러리가 아닌 병렬라우트 및 라우트 인터셉트로 구현
  - 외부라이브러리 의존없이 router push와 back으로 모달을 열고 닫을 수 있음
  - 뒤로가기 키 누르면 닫아짐
- modal은 앞에 나와야하므로 높은 z-index,position fixed,전체 뷰포트를 덮는 영역을 가짐
## 📸 동작 화면 스크린샷
![image](https://github.com/user-attachments/assets/4f9329c3-5a6e-4624-8f94-c60c5c587301)
오오 글자는 그냥 암거나 친거
## 👀 기타 논의 사항
* 기획의도에 따라 상태관리 또는 overlay toolkit사용이 옳을 수 있음
* nested modal 구현은 나중에 생각할 예정