### PR TITLE
156 user info modal

### DIFF
--- a/packages/front-end/app/dashboard/(data)/session/_components/SessionTable.tsx
+++ b/packages/front-end/app/dashboard/(data)/session/_components/SessionTable.tsx
@@ -16,6 +16,7 @@ import { Session } from "@/schema/backend.schema";
 import { css } from "@/styled-system/css";
 import { apiClient } from "@/util/axios";
 import { useSuspenseQuery } from "@tanstack/react-query";
+import { AxiosResponse } from "axios";
 import { formatDate } from "date-fns";
 import { ChangeEvent, Dispatch, SetStateAction } from "react";
 
@@ -24,14 +25,14 @@ export default function SessionTable() {
   if (!queryObj["role"]) {
     queryObj["role"] = "participant";
   }
-  const { data } = useSuspenseQuery({
+  const { data } = useSuspenseQuery<AxiosResponse<Session[]>>({
     queryKey: ["user", "sessions", queryObj["role"]],
     queryFn: async () => {
       return await apiClient.get("/user/sessions/list", {
         params: queryObj,
       });
     },
-  }).data.data;
+  }).data;
 
   console.log(data);
 

--- a/packages/front-end/app/dashboard/@modal/user-menu/_components/UserInfoEdit.tsx
+++ b/packages/front-end/app/dashboard/@modal/user-menu/_components/UserInfoEdit.tsx
@@ -1,0 +1,41 @@
+import Button from "@/components/Button";
+import { Heading, Paragraph } from "@/components/Text";
+import { css } from "@/styled-system/css";
+import { apiClient } from "@/util/axios";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { AxiosResponse } from "axios";
+import Image from "next/image";
+import { ChangeEvent, useRef } from "react";
+
+export default function UserInfoEdit() {
+  const { data: response } = useSuspenseQuery<AxiosResponse<any>>({
+    queryKey: ["user", "profile"],
+    queryFn: async () => await apiClient.get("/user/profile"),
+  });
+  const data = response.data;
+  const nicknameRef = useRef<string>();
+  const handleNicknameInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    nicknameRef.current = e.target.value;
+  };
+  return (
+    <>
+      <Heading variant="h5">내 정보 수정</Heading>
+      <div
+        className={css({
+          display: "flex",
+          justifyContent: "space-between",
+        })}
+      >
+        <div>
+          <Paragraph variant="sub3">아바타</Paragraph>
+          <Image src={data.profileUrl} alt="profile image" />
+        </div>
+        <div>
+          <Paragraph variant="sub3">닉네임</Paragraph>
+          <input onChange={handleNicknameInputChange} />
+        </div>
+      </div>
+      <Button type="submit">수정하기</Button>
+    </>
+  );
+}

--- a/packages/front-end/app/dashboard/@modal/user-menu/_components/UserModal.tsx
+++ b/packages/front-end/app/dashboard/@modal/user-menu/_components/UserModal.tsx
@@ -4,9 +4,13 @@ import Divider from "@/components/Divider";
 import ModalContainer from "@/components/ModalContainer";
 import { css } from "@/styled-system/css";
 import UserModalTop from "./UserModalTop";
+import { Heading } from "@/components/Text";
+import Button from "@/components/Button";
+import UserInfoEdit from "./UserInfoEdit";
+import { Suspense } from "react";
+import { ErrorBoundary } from "react-error-boundary";
 
 export default function UserModal() {
-  
   return (
     <ModalContainer>
       <div
@@ -22,9 +26,17 @@ export default function UserModal() {
           e.stopPropagation();
         }}
       >
-        <UserModalTop/>
+        <UserModalTop />
         <Divider />
-
+        <div>
+          <ErrorBoundary fallback={<h1>에러</h1>}>
+            <Suspense fallback={<h1>로딩</h1>}>
+              <UserInfoEdit />
+            </Suspense>
+          </ErrorBoundary>
+          <Heading variant="h5">로그아웃</Heading>
+          <Button>로그아웃</Button>
+        </div>
       </div>
     </ModalContainer>
   );

--- a/packages/front-end/app/dashboard/@modal/user-menu/_components/UserModal.tsx
+++ b/packages/front-end/app/dashboard/@modal/user-menu/_components/UserModal.tsx
@@ -1,10 +1,7 @@
 "use client";
 
-import Button from "@/components/Button";
 import Divider from "@/components/Divider";
 import ModalContainer from "@/components/ModalContainer";
-import { Heading } from "@/components/Text";
-import { useRouter } from "@/hook/useRouter";
 import { css } from "@/styled-system/css";
 import UserModalTop from "./UserModalTop";
 

--- a/packages/front-end/app/dashboard/@modal/user-menu/_components/UserModal.tsx
+++ b/packages/front-end/app/dashboard/@modal/user-menu/_components/UserModal.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import Button from "@/components/Button";
+import Divider from "@/components/Divider";
+import ModalContainer from "@/components/ModalContainer";
+import { Heading } from "@/components/Text";
+import { useRouter } from "@/hook/useRouter";
+import { css } from "@/styled-system/css";
+import UserModalTop from "./UserModalTop";
+
+export default function UserModal() {
+  
+  return (
+    <ModalContainer>
+      <div
+        className={css({
+          backgroundColor: "white",
+          borderRadius: "1rem",
+          border: "1px solid",
+          borderColor: "gray.100",
+          padding: "1.5rem 1rem",
+          width: "600px",
+        })}
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
+      >
+        <UserModalTop/>
+        <Divider />
+
+      </div>
+    </ModalContainer>
+  );
+}

--- a/packages/front-end/app/dashboard/@modal/user-menu/_components/UserModalTop.tsx
+++ b/packages/front-end/app/dashboard/@modal/user-menu/_components/UserModalTop.tsx
@@ -1,0 +1,26 @@
+import Button from "@/components/Button";
+import { Heading } from "@/components/Text";
+import { useRouter } from "@/hook/useRouter";
+import { css } from "@/styled-system/css";
+
+export default function UserModalTop() {
+  const router = useRouter();
+  return (
+    <div
+      className={css({
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+      })}
+    >
+      <Heading>내 정보</Heading>
+      <Button
+        onClick={() => {
+          router.back();
+        }}
+      >
+        X
+      </Button>
+    </div>
+  );
+}

--- a/packages/front-end/app/dashboard/@modal/user-menu/page.tsx
+++ b/packages/front-end/app/dashboard/@modal/user-menu/page.tsx
@@ -1,5 +1,6 @@
 import ModalContainer from "@/components/ModalContainer";
+import UserModal from "./_components/UserModal";
 
 export default function Page() {
-  return <ModalContainer>오오</ModalContainer>;
+  return <UserModal/>;
 }

--- a/packages/front-end/mocks/handlers.ts
+++ b/packages/front-end/mocks/handlers.ts
@@ -5,8 +5,4 @@ import {
   userSessionHandler,
 } from "./handlers/user";
 
-export const handlers: HttpHandler[] = [
-  
-  userFileHandler,
-  tokenRefreshHandler,
-];
+export const handlers: HttpHandler[] = [userFileHandler];


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가

## ❗️ 관련 이슈 [#]
close #156 
## 📄 개요
- 유저 모달에 필요한 것들 기초공사

## 🔁 변경 사항
- 유저정보 수정할 것이 별로 없어 로그아웃과 유저 정보 수정을 한페이지에
- 리프레시토큰 api 수정 필요(현재 서버단 에러 발생)
- 따라서, 정확한 테스트는 아직 못함 단 api연동전에 ui는 제대로나옴(애초에 에러발생할 것이 없음)

## 📸 동작 화면 스크린샷
![image](https://github.com/user-attachments/assets/0cb8ceba-cda3-409f-9c5e-e23c4098a0ee)
- 에러 바운더리로 인해 단순 에러 발생, 단 에러 바운더리 영역에 제목이 포함되는건 안좋아보임

## 👀 기타 논의 사항
- 추후 프로필사진 ui를 변경해야함(borderRad 50%)
