### PR TITLE
feat: get user and session info at session detail

### DIFF
--- a/packages/front-end/app/dashboard/(data)/session/_components/SessionTable.tsx
+++ b/packages/front-end/app/dashboard/(data)/session/_components/SessionTable.tsx
@@ -16,27 +16,41 @@ import { useRouter } from "@/hook/useRouter";
 import { Session } from "@/schema/backend.schema";
 import { css } from "@/styled-system/css";
 import { apiClient } from "@/util/axios";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { AxiosResponse } from "axios";
 import { formatDate } from "date-fns";
 import { ChangeEvent, Dispatch, SetStateAction } from "react";
 
-export default function SessionTable() {
+export default function SessionTableFetch() {
   const { queryObj } = useRouter();
   if (!queryObj["role"]) {
     queryObj["role"] = "participant";
   }
-  const { data: response } = useSuspenseQuery<AxiosResponse<Session[]>>({
+  const { data: response, isLoading } = useQuery<AxiosResponse<Session[]>>({
     queryKey: ["user", "sessions", queryObj["role"]],
     queryFn: async () => {
       return await apiClient.get("/user/sessions", {
         params: queryObj,
       });
     },
+    throwOnError: true,
   });
+  const data = response?.data;
+  if (isLoading){
+    return <h1>로딩...</h1>
+  }
+  return <>{data !== undefined && <SessionTable data={data} />}</>;
+}
 
-  const data = response.data;
-  console.log(data);
+interface SessionTablePropType {
+  data: Session[];
+}
+
+export function SessionTable({ data }: SessionTablePropType) {
+  const { queryObj } = useRouter();
+  if (!queryObj["role"]) {
+    queryObj["role"] = "participant";
+  }
   const { isTotalChecked, setIsTotalChecked, setIsCheckedOne, isCheckedOne } =
     useCheckBoxes<Session, number>({
       data: data,

--- a/packages/front-end/app/dashboard/(data)/session/page.tsx
+++ b/packages/front-end/app/dashboard/(data)/session/page.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { Suspense } from "react";
-import SessionTable from "./_components/SessionTable";
 import { ErrorBoundary } from "react-error-boundary";
 import SessionHeader from "./_components/SessionHeader";
 import { useQueryErrorResetBoundary } from "@tanstack/react-query";
+import SessionTableFetch from "./_components/SessionTable";
 
 export default function Page() {
   const { reset } = useQueryErrorResetBoundary();
@@ -12,11 +11,9 @@ export default function Page() {
   return (
     <>
       <SessionHeader />
-      <Suspense fallback={<h1>로딩...</h1>}>
-        <ErrorBoundary fallback={<h1>에러</h1>} onReset={reset}>
-          <SessionTable />
-        </ErrorBoundary>
-      </Suspense>
+      <ErrorBoundary fallback={<h1>에러</h1>} onReset={reset}>
+        <SessionTableFetch />
+      </ErrorBoundary>
     </>
   );
 }

--- a/packages/front-end/app/sessions/[sessionId]/detail/_components/HostSession/index.tsx
+++ b/packages/front-end/app/sessions/[sessionId]/detail/_components/HostSession/index.tsx
@@ -1,0 +1,3 @@
+export default function HostSession(){
+    return <></>
+}

--- a/packages/front-end/app/sessions/[sessionId]/detail/_components/ParticipantSession/index.tsx
+++ b/packages/front-end/app/sessions/[sessionId]/detail/_components/ParticipantSession/index.tsx
@@ -1,0 +1,3 @@
+export default function ParticipantSession(){
+    return <></>
+}

--- a/packages/front-end/app/sessions/[sessionId]/detail/error.tsx
+++ b/packages/front-end/app/sessions/[sessionId]/detail/error.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useEffect } from "react";
+
+interface PropType {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function Error({ error, reset }: PropType) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+  return <h1>{`에러:${error.message}`}</h1>;
+}

--- a/packages/front-end/app/sessions/[sessionId]/detail/page.tsx
+++ b/packages/front-end/app/sessions/[sessionId]/detail/page.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { apiClient } from "@/util/axios";
+import { useQueries, useQuery } from "@tanstack/react-query";
+import { AxiosResponse } from "axios";
+
+interface PropType {
+  params: { sessionId: string };
+}
+
+export default function Page({ params }: PropType) {
+  const sessionId = Number(params.sessionId);
+  const [
+    { data: userRes, isLoading: isUserLoading },
+    { data: sessionRes, isLoading: isSessionLoading },
+  ] = useQueries<[AxiosResponse<any>, AxiosResponse<any>]>({
+    queries: [
+      {
+        queryKey: ["user", "profile"],
+        queryFn: async () => await apiClient.get("/user/profile"),
+        throwOnError: true,
+      },
+      {
+        queryKey: ["session", sessionId],
+        queryFn: async () => await apiClient.get(`/session/${sessionId}/info`),
+        throwOnError: true,
+      },
+    ],
+  });
+  if (isUserLoading || isSessionLoading) {
+    return <h1>로딩...</h1>;
+  }
+
+  return <></>;
+}

--- a/packages/front-end/provider/query-client-provider.tsx
+++ b/packages/front-end/provider/query-client-provider.tsx
@@ -3,21 +3,27 @@ import {
   QueryClient,
   QueryClientProvider as _QueryClientProvider,
 } from "@tanstack/react-query";
-import { ReactNode } from "react";
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: 1,
-    },
-  },
-});
+import { ReactNode, useState } from "react";
 
 interface PropType {
   children: ReactNode;
 }
 
 export default function QueryClientProvider({ children }: PropType) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            retry: 1,
+          },
+          dehydrate: {
+            shouldDehydrateMutation: (_mutation) => false,
+            shouldDehydrateQuery: (_query) => false,
+          },
+        },
+      })
+  );
   return (
     <_QueryClientProvider client={queryClient}>{children}</_QueryClientProvider>
   );

--- a/packages/front-end/schema/backend.schema.ts
+++ b/packages/front-end/schema/backend.schema.ts
@@ -42,6 +42,16 @@ export type UserSessionBodyType = object;
 
 export type UpdateResult = object;
 
+export interface File {
+  fileId: number;
+  ownerId: number;
+  name: string;
+  url: string;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string;
+}
+
 export interface CreateSessionDto {
   sessionName: string;
   sessionFileIds: string[];
@@ -419,12 +429,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       },
       params: RequestParams = {},
     ) =>
-      this.request<Session | UserSession, any>({
+      this.request<any, Session[]>({
         path: `/user/sessions`,
         method: 'GET',
         query: query,
         secure: true,
-        format: 'json',
         ...params,
       }),
 
@@ -476,6 +485,22 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       this.request<any, UserSession>({
         path: `/user/sessions/${sessionId}`,
         method: 'DELETE',
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags user
+     * @name UsersControllerGetUserFiles
+     * @request GET:/user/files
+     * @secure
+     */
+    usersControllerGetUserFiles: (params: RequestParams = {}) =>
+      this.request<any, File>({
+        path: `/user/files`,
+        method: 'GET',
         secure: true,
         ...params,
       }),

--- a/packages/front-end/util/axios.ts
+++ b/packages/front-end/util/axios.ts
@@ -50,6 +50,7 @@ apiClient.interceptors.request.use(
   (config) => {
     const accessToken = Cookies.get("access_token");
     config.headers.Authorization = `Bearer ${accessToken}`;
+    console.log("req",config);
     return config;
   },
   (error) => {
@@ -59,10 +60,12 @@ apiClient.interceptors.request.use(
 
 apiClient.interceptors.response.use(
   (response) => {
+    console.log("success", response);
     return response.data;
   },
   async (error) => {
     const originalReq = error.config as InternalAxiosRequestConfig<any>;
+    console.log(error, originalReq);
     if (error?.response?.status === 401) {
       try {
         await refreshClient.get("/auth/token-refresh");


### PR DESCRIPTION
세션 상세보기 페이지에서 유저정보와 세션정보를 읽어옴:

## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가

## ❗️ 관련 이슈 [#]
#167 
#172 
## 📄 개요
- session detail page에 세션id에 따른 세션 정보와 현재 로그인한 유저 정보 받아옴
## 🔁 변경 사항
- session table에 시험적으로 api call 형식 지정
- session detail페이지에 api call 형식 적용
- waterfall 방지 위해 useQueries 사용
- api 타입이 불완전한 것 같아 backend schema 명령 작동
- 그럼에도 불완전 한 것 같아 임시적으로 응답타입은 axiosResponse<any> 사용

## 📸 동작 화면 스크린샷

## 👀 기타 논의 사항