### PR TITLE
feat: participant session detail

### DIFF
--- a/packages/front-end/app/sessions/[sessionId]/detail/_components/ParticipantSession/index.tsx
+++ b/packages/front-end/app/sessions/[sessionId]/detail/_components/ParticipantSession/index.tsx
@@ -1,3 +1,41 @@
-export default function ParticipantSession(){
-    return <></>
+import Button from "@/components/Button";
+import { Heading, Paragraph } from "@/components/Text";
+import { SessionResponseDto } from "@/schema/backend.schema";
+import { css } from "@/styled-system/css";
+
+interface PropType {
+  sessionData: SessionResponseDto;
+}
+
+export default function ParticipantSession({ sessionData }: PropType) {
+  return (
+    <main
+      className={css({
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        width: "100vw",
+        height: "100vh",
+      })}
+    >
+      <div
+        className={css({
+          display: "flex",
+          flexDirection: "column",
+          width: "600px",
+          gap: "1rem",
+        })}
+      >
+        <Heading>세션 정보 및 작성</Heading>
+        <Paragraph>세션 제목</Paragraph>
+        <Paragraph>{sessionData.sessionName}</Paragraph>
+        <Paragraph>현재 선택한 파일</Paragraph>
+        {sessionData.fileList.map((file) => (
+          <Paragraph key={file.fileId}>{file.name}</Paragraph>
+        ))}
+        <Paragraph>파일 제목 목록</Paragraph>
+        <Button type="submit">세션 참여</Button>
+      </div>
+    </main>
+  );
 }

--- a/packages/front-end/app/sessions/[sessionId]/detail/page.tsx
+++ b/packages/front-end/app/sessions/[sessionId]/detail/page.tsx
@@ -43,7 +43,7 @@ export default function Page({ params }: PropType) {
         (userData.userId === sessionData.hostId ? (
           <HostSession sessionData={sessionData} />
         ) : (
-          <ParticipantSession />
+          <ParticipantSession sessionData={sessionData}/>
         ))}
     </>
   );


### PR DESCRIPTION
참여자입장 세션 디테일 페이지

## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가

## ❗️ 관련 이슈 [#]
close #192
## 📄 개요
- 참여자 입장에서 (session Hostid와 userid가 다른 입장에서) 세션 디테일 페이지 

## 🔁 변경 사항
- input 필드 지움
- 파일 업로드 모달 지움
- label대신 p태그 사용

## 📸 동작 화면 스크린샷
![image](https://github.com/user-attachments/assets/5f8ed411-e77e-48b6-89bd-33fbc2292433)

## 👀 기타 논의 사항