### PR TITLE
fix: drive table data fetch

### DIFF
--- a/packages/front-end/app/files/_components/FileTable.tsx
+++ b/packages/front-end/app/files/_components/FileTable.tsx
@@ -11,31 +11,33 @@ import {
   Th,
 } from "@/components/Table";
 import { useCheckBoxes } from "@/hook/useCheckBoxes";
-import { useRouter } from "@/hook/useRouter";
+import { File } from "@/schema/backend.schema";
 import { css } from "@/styled-system/css";
 import { apiClient } from "@/util/axios";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { formatDate } from "date-fns";
 import { ChangeEvent, Dispatch, SetStateAction } from "react";
 
-export default function FileTable() {
-  const { queryObj } = useRouter();
-  if (!queryObj["role"]) {
-    queryObj["role"] = "participant";
-  }
-  const { data } = useSuspenseQuery({
-    queryKey: ["user", "sessions", queryObj["role"]],
+export default function FileTableFetch() {
+  const { data: fileRes, isLoading } = useQuery({
+    queryKey: ["user", "files"],
     queryFn: async () => {
-      const { data } = await apiClient.get<any[]>("/user/files", {
-        params: queryObj,
-      });
-      return data;
+      return await apiClient.get<File[]>("/user/files");
     },
+    throwOnError: true,
   });
+  if (isLoading) {
+    return <h1>로딩중...</h1>;
+  }
+  const data = fileRes?.data;
+  return <>{data && <FileTable data={data} />}</>;
+}
+
+export function FileTable({ data }: { data: File[] }) {
   const { isTotalChecked, setIsTotalChecked, setIsCheckedOne, isCheckedOne } =
-    useCheckBoxes<any, number>({
+    useCheckBoxes<File, number>({
       data: data,
-      id: "id",
+      id: "fileId",
       areCheckedAtom: fileAreCheckedAtom,
       isTotalCheckedAtom: fileIsTotalCheckedAtom,
     });
@@ -51,7 +53,15 @@ export default function FileTable() {
         setIsTotalChecked={setIsTotalChecked}
         isTotalChecked={isTotalChecked}
       />
-      <TableBody>{/* add row component */}</TableBody>
+      <TableBody>
+        {data.map((e) => (
+          <Row
+            el={e}
+            isCheckedOne={isCheckedOne}
+            setIsCheckedOne={setIsCheckedOne}
+          />
+        ))}
+      </TableBody>
     </TableContainer>
   );
 }
@@ -88,7 +98,7 @@ function Row({
   setIsCheckedOne,
   isCheckedOne,
 }: {
-  el: any;
+  el: File;
   setIsCheckedOne: (id: number, value: boolean) => void;
   isCheckedOne: (id: number) => boolean;
 }) {
@@ -109,10 +119,10 @@ function Row({
         <input
           type="checkbox"
           onChange={handleChange}
-          checked={isCheckedOne(el.sessionId)}
+          checked={isCheckedOne(el.fileId)}
         />
       </Td>
-      <Td>{el.fileName}</Td>
+      <Td>{el.name}</Td>
       <Td>{formatDate(el.createdAt, "yyyy-MM-dd")}</Td>
     </TableRow>
   );

--- a/packages/front-end/app/files/page.tsx
+++ b/packages/front-end/app/files/page.tsx
@@ -1,17 +1,14 @@
 "use client";
 
-import { Suspense } from "react";
-import FileTable from "./_components/FileTable";
+import FileTableFetch from "./_components/FileTable";
 import { ErrorBoundary } from "react-error-boundary";
 
 export default function Page() {
   return (
     <>
-      <Suspense fallback={<h1>로딩...</h1>}>
-        <ErrorBoundary fallback={<h1>에러</h1>}>
-          <FileTable />
-        </ErrorBoundary>
-      </Suspense>
+      <ErrorBoundary fallback={<h1>에러</h1>}>
+        <FileTableFetch />
+      </ErrorBoundary>
     </>
   );
 }


### PR DESCRIPTION
드라이브 테이블에서 데이터 형식이 맞지않아 ui가 안뜨는 오류 해결

## 📍 PR 타입 (하나 이상 선택)
- [ ] 버그 수정

## ❗️ 관련 이슈 [#]
close #196 
## 📄 개요
- 드라이브 테이블에서 api 페칭 중 에러 발생해 수정

## 🔁 변경 사항
- useSuspenseQuery를 useQuery로 대체
- 일관성을 위해 queryFn에서 response.data를 뽑아오는 로직 삭제
- [discussions](https://github.com/Uni-class/catch-up-repo/discussions/174)에서 제시한 구조에 맞게 코드 구조 수정
- backend schema의 File 타입을 이용해 잘못된 property와 any타입을 사용하는 코드를 지우고 type safety한 코드 작성

## 📸 동작 화면 스크린샷
- 이제 잘뜸
![image](https://github.com/user-attachments/assets/59406301-cb40-468e-b14d-27a4a0a6b05d)

## 👀 기타 논의 사항