### PR TITLE
fix: api call with valid role query param

### DIFF
--- a/packages/front-end/app/(sidebar-pages)/layout.tsx
+++ b/packages/front-end/app/(sidebar-pages)/layout.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { ReactNode } from "react";
 import { css } from "@/styled-system/css";
 import Sidebar from "@/app/(sidebar-pages)/_components/Sidebar";

--- a/packages/front-end/app/(sidebar-pages)/sessions/host/_components/SessionTable.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/host/_components/SessionTable.tsx
@@ -15,21 +15,20 @@ import { useRouter } from "@/hook/useRouter";
 import { Session } from "@/schema/backend.schema";
 import { css } from "@/styled-system/css";
 import { apiClient } from "@/util/axios";
+import getRoleFromURL from "@/util/getRoleFromURL";
 import { useQuery } from "@tanstack/react-query";
 import { AxiosResponse } from "axios";
 import { formatDate } from "date-fns";
 import { ChangeEvent, Dispatch, SetStateAction } from "react";
 
 export default function SessionTableFetch() {
-  const { queryObj } = useRouter();
-  if (!queryObj["role"]) {
-    queryObj["role"] = "participant";
-  }
+  const { pathname } = useRouter();
+  const role = getRoleFromURL(pathname);
   const { data: response, isLoading } = useQuery<AxiosResponse<Session[]>>({
-    queryKey: ["user", "sessions", queryObj["role"]],
+    queryKey: ["user", "sessions", role],
     queryFn: async () => {
       return await apiClient.get("/user/sessions", {
-        params: queryObj,
+        params: {role},
       });
     },
     throwOnError: true,
@@ -38,7 +37,7 @@ export default function SessionTableFetch() {
   if (isLoading) {
     return <h1>로딩...</h1>;
   }
-  return data !== undefined && <SessionTable data={data} />
+  return data !== undefined && <SessionTable data={data} />;
 }
 
 interface SessionTablePropType {

--- a/packages/front-end/app/(sidebar-pages)/sessions/participant/_components/SessionTable.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/participant/_components/SessionTable.tsx
@@ -16,21 +16,20 @@ import { useRouter } from "@/hook/useRouter";
 import { Session } from "@/schema/backend.schema";
 import { css } from "@/styled-system/css";
 import { apiClient } from "@/util/axios";
+import getRoleFromURL from "@/util/getRoleFromURL";
 import { useQuery } from "@tanstack/react-query";
 import { AxiosResponse } from "axios";
 import { formatDate } from "date-fns";
 import { ChangeEvent, Dispatch, SetStateAction } from "react";
 
 export default function SessionTableFetch() {
-  const { queryObj } = useRouter();
-  if (!queryObj["role"]) {
-    queryObj["role"] = "participant";
-  }
+  const { pathname } = useRouter();
+  const role = getRoleFromURL(pathname);
   const { data: response, isLoading } = useQuery<AxiosResponse<Session[]>>({
-    queryKey: ["user", "sessions", queryObj["role"]],
+    queryKey: ["user", "sessions", role],
     queryFn: async () => {
       return await apiClient.get("/user/sessions", {
-        params: queryObj,
+        params: {role},
       });
     },
     throwOnError: true,

--- a/packages/front-end/util/getRoleFromURL.tsx
+++ b/packages/front-end/util/getRoleFromURL.tsx
@@ -1,0 +1,3 @@
+export default function getRoleFromURL(pathname: string): string {
+  return pathname.split("/").at(-1) || "participant";
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5714,13 +5714,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/js-cookie@npm:^3":
-  version: 3.0.6
-  resolution: "@types/js-cookie@npm:3.0.6"
-  checksum: 10c0/173afaf5ea9d86c22395b9d2a00b6adb0006dcfef165d6dcb0395cdc32f5a5dcf9c3c60f97194119963a15849b8f85121e1ae730b03e40bc0c29b84396ba22f9
-  languageName: node
-  linkType: hard
-
 "@types/json-schema@npm:*, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
@@ -10615,7 +10608,6 @@ __metadata:
     "@svgr/webpack": "npm:^8.1.0"
     "@tanstack/eslint-plugin-query": "npm:^5.50.1"
     "@tanstack/react-query": "npm:^5.50.1"
-    "@types/js-cookie": "npm:^3"
     "@types/node": "npm:^20"
     "@types/react": "npm:^18"
     "@types/react-dom": "npm:^18"
@@ -10625,7 +10617,6 @@ __metadata:
     eslint-config-next: "npm:14.2.4"
     eslint-plugin-storybook: "npm:^0.8.0"
     jotai: "npm:^2.9.0"
-    js-cookie: "npm:^3.0.5"
     msw: "npm:^2.3.1"
     next: "npm:14.2.4"
     overlay-kit: "npm:^1.3.0"
@@ -12522,13 +12513,6 @@ __metadata:
     react:
       optional: true
   checksum: 10c0/c5551fb90933bcbc28b11cdb4af681398a12f8eb39a4a49568ec6ce5062c2257dd84a85cbfd7ec7d970d56dfa5023d16a0ec7056bc2697fdf9b3ec94da67c9d1
-  languageName: node
-  linkType: hard
-
-"js-cookie@npm:^3.0.5":
-  version: 3.0.5
-  resolution: "js-cookie@npm:3.0.5"
-  checksum: 10c0/04a0e560407b4489daac3a63e231d35f4e86f78bff9d792011391b49c59f721b513411cd75714c418049c8dc9750b20fcddad1ca5a2ca616c3aca4874cce5b3a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
getRoleFromURL을 이용

## 📍 PR 타입 (하나 이상 선택)
- [ ] 버그 수정

## ❗️ 관련 이슈 [#]
close #209 
## 📄 개요
- 백엔드 api에 올바른 쿼리파라미터를 보내도록함
- pathname을 읽어와 role에 해당하는 string을 뽑아오는 함수
- 해당 함수 두개의 session table에 적용

## 🔁 변경 사항
### 라우팅 정책이 바뀔때를 대비해 util/에 함수 작성
```
export default function getRoleFromURL(pathname: string): string {
  return pathname.split("/").at(-1) || "participant";
}
```
- type safety를 위해 default로 참가자역할을 리턴하지만, 실제사용시 위험할 일은 없음(어차피 라우팅구조가 같다면?)
- as string으로 type casting을 해도 무방하다 생각
### 실적용
```
  const { pathname } = useRouter();
  const role = getRoleFromURL(pathname);
  const { data: response, isLoading } = useQuery<AxiosResponse<Session[]>>({
    queryKey: ["user", "sessions", role],
    queryFn: async () => {
      return await apiClient.get("/user/sessions", {
        params: {role},
      });
    },
    throwOnError: true,
  });
```
- 이제 쿼리파라미터가 아닌 route seg로 라우팅하므로 pathname 받아옴
- role에 우리가 원하는 참여자 또는 호스트 역할 스트링이 담겨있음
- axios query param은 object여야하므로 {role}이용 어차피 서버에서도 role로 받고, 값도 클라에서 role로 담겨있음
## 📸 동작 화면 스크린샷

## 👀 기타 논의 사항