### PR TITLE
Be/227 patch user profile fix

### DIFF
--- a/packages/api-server/src/users/dto/update-user-profile.dto.ts
+++ b/packages/api-server/src/users/dto/update-user-profile.dto.ts
@@ -1,0 +1,9 @@
+import { PartialType, PickType } from '@nestjs/swagger';
+import { CreateUserDto } from './create-user.dto';
+
+export class UpdateUserProfileDto extends PickType(PartialType(CreateUserDto), [
+  'nickname',
+  'email',
+]) {
+  profileUrl?: string;
+}

--- a/packages/api-server/src/users/dto/update-user.dto.ts
+++ b/packages/api-server/src/users/dto/update-user.dto.ts
@@ -1,12 +1,10 @@
 import { ApiProperty, PartialType, PickType } from '@nestjs/swagger';
 import { CreateUserDto } from './create-user.dto';
-import {IsNumber, IsOptional, IsString} from 'class-validator';
+import { IsNumber, IsOptional, IsString } from 'class-validator';
 
 export class UpdateUserDto extends PickType(PartialType(CreateUserDto), [
   'nickname',
   'email',
-]) {
-  @IsOptional()
-  @IsString()
-  profileUrl: string;
-}
+  'profileUrl',
+  'refreshToken',
+]) {}

--- a/packages/api-server/src/users/dto/update-user.dto.ts
+++ b/packages/api-server/src/users/dto/update-user.dto.ts
@@ -1,10 +1,12 @@
 import { ApiProperty, PartialType, PickType } from '@nestjs/swagger';
 import { CreateUserDto } from './create-user.dto';
-import { IsNumber } from 'class-validator';
+import {IsNumber, IsOptional, IsString} from 'class-validator';
 
 export class UpdateUserDto extends PickType(PartialType(CreateUserDto), [
   'nickname',
   'email',
-  'profileUrl',
-  'refreshToken',
-]) {}
+]) {
+  @IsOptional()
+  @IsString()
+  profileUrl: string;
+}

--- a/packages/api-server/src/users/users.module.ts
+++ b/packages/api-server/src/users/users.module.ts
@@ -5,11 +5,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from './entities/user.entity';
 import { Session } from '../sessions/entities/session.entity';
 import { UserSession } from '../user-sessions/entities/user-session.entity';
+import { FilesService } from '../files/files.service';
+import { File } from '../files/entities/file.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User, Session, UserSession])],
+  imports: [TypeOrmModule.forFeature([User, Session, UserSession, File])],
   controllers: [UsersController],
-  providers: [UsersService],
+  providers: [UsersService, FilesService],
   exports: [UsersService],
 })
 export class UsersModule {}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가

## ❗️ 관련 이슈 [#]
close #227 

## 📄 개요
- PATCH /user/profile 로직 수정
- UpdateUserProfileDto 추가

## 🔁 변경 사항
### 변경 내용을 적어주세요 (커밋 번호를 적어주세요)
- e48314aa696dc1f9978b37d09af7d30d7fb213d3 : 리프레시 토큰은 클라이언트가 수정하지 못하도록 다른 DTO를 생성함
- 85cdb49d218033b807b9fbffb30bda7a850931bc : 사진 파일을 받아서 S3에 저장하고, 그 URL을 User DB에 저장하도록 변경, 모든 데이터는 multipart/form-data 로 보내면 됨

## 📸 동작 화면 스크린샷

## 👀 기타 논의 사항