### PR TITLE
252 file delete

### DIFF
--- a/packages/api-server/src/files/files.service.ts
+++ b/packages/api-server/src/files/files.service.ts
@@ -70,7 +70,7 @@ export class FilesService {
   }
 
   async s3Upload(userId: number, file: Express.Multer.File) {
-    const fileName: string = Buffer.from(file.originalname).toString('utf8');
+    const fileName: string = Buffer.from(file.originalname, 'latin1').toString('utf8').normalize('NFC');
     const key: string = `${Date.now().toString()}-${fileName}`;
     const param = {
       Key: key,

--- a/packages/api-server/src/files/files.service.ts
+++ b/packages/api-server/src/files/files.service.ts
@@ -70,7 +70,9 @@ export class FilesService {
   }
 
   async s3Upload(userId: number, file: Express.Multer.File) {
-    const fileName: string = Buffer.from(file.originalname, 'latin1').toString('utf8').normalize('NFC');
+    const fileName: string = Buffer.from(file.originalname, 'latin1', 'latin1')
+      .toString('utf8').normalize('NFC')
+      .normalize('NFC');
     const key: string = `${Date.now().toString()}-${fileName}`;
     const param = {
       Key: key,

--- a/packages/front-end/app/(sidebar-pages)/files/_components/FileTable.tsx
+++ b/packages/front-end/app/(sidebar-pages)/files/_components/FileTable.tsx
@@ -92,7 +92,8 @@ export function FileTable({
         })
       ),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["user files"] });
+      queryClient.invalidateQueries({ queryKey: ["user", "files"] });
+      queryClient.refetchQueries({queryKey:["user","files"]})
     },
     onError: (e) => {
       console.error(e);

--- a/packages/front-end/app/(sidebar-pages)/files/_components/FileTable.tsx
+++ b/packages/front-end/app/(sidebar-pages)/files/_components/FileTable.tsx
@@ -7,7 +7,8 @@ import SelectableTable from "@/components/SelectableTable";
 import { overlay } from "overlay-kit";
 import ModalContainer from "@/components/ModalContainer";
 import FileUploadModal from "@/app/(sidebar-pages)/files/_components/FileUploadModal";
-
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiClient } from "@/util/axios";
 
 const showFileUploadModal = () => {
   overlay.open(
@@ -20,16 +21,17 @@ const showFileUploadModal = () => {
   );
 };
 
-
 const DataEmptyPlaceholder = (
-  <div className={css({
-    display: "flex",
-    padding: "1em",
-    flexDirection: "column",
-    justifyContent: "center",
-    alignItems: "center",
-    gap: "0.5em",
-  })}>
+  <div
+    className={css({
+      display: "flex",
+      padding: "1em",
+      flexDirection: "column",
+      justifyContent: "center",
+      alignItems: "center",
+      gap: "0.5em",
+    })}
+  >
     <p>표시할 데이터가 없습니다.</p>
     <p>새로운 파일을 업로드해 보세요!</p>
     <Button
@@ -43,49 +45,75 @@ const DataEmptyPlaceholder = (
   </div>
 );
 
-
 const LoadingPlaceholder = (
-  <div className={css({
-    display: "flex",
-    padding: "1em",
-    flexDirection: "column",
-    justifyContent: "center",
-    alignItems: "center",
-    gap: "0.5em",
-  })}>
+  <div
+    className={css({
+      display: "flex",
+      padding: "1em",
+      flexDirection: "column",
+      justifyContent: "center",
+      alignItems: "center",
+      gap: "0.5em",
+    })}
+  >
     <p>불러오는 중...</p>
   </div>
 );
 
-
 const ErrorPlaceholder = (
-  <div className={css({
-    display: "flex",
-    padding: "1em",
-    flexDirection: "column",
-    justifyContent: "center",
-    alignItems: "center",
-    gap: "0.5em",
-  })}>
+  <div
+    className={css({
+      display: "flex",
+      padding: "1em",
+      flexDirection: "column",
+      justifyContent: "center",
+      alignItems: "center",
+      gap: "0.5em",
+    })}
+  >
     <p>오류가 발생하였습니다.</p>
   </div>
 );
 
-
-export function FileTable({data, status = null}: { data: File[], status?: "loading" | "error" | null }) {
+export function FileTable({
+  data,
+  status = null,
+}: {
+  data: File[];
+  status?: "loading" | "error" | null;
+}) {
+  const queryClient = useQueryClient();
   const [selectedItems, setSelectedItems] = useState<number[]>([]);
+  const fileMutate = useMutation({
+    mutationFn: async (selectedItems: number[]) =>
+      Promise.all(
+        selectedItems.map(async (e) => {
+          await apiClient.delete(`/file/${e}`);
+        })
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["user files"] });
+    },
+    onError: (e) => {
+      console.error(e);
+    },
+  });
 
   return (
-    <div className={css({
-      display: "flex",
-      flexDirection: "column",
-      gap: "0.6em",
-    })}>
-      <div className={css({
+    <div
+      className={css({
         display: "flex",
-        gap: "1em",
-        justifyContent: "flex-end",
-      })}>
+        flexDirection: "column",
+        gap: "0.6em",
+      })}
+    >
+      <div
+        className={css({
+          display: "flex",
+          gap: "1em",
+          justifyContent: "flex-end",
+        })}
+      >
         <Button
           className={css({
             padding: "0.5em 0.8em",
@@ -96,12 +124,13 @@ export function FileTable({data, status = null}: { data: File[], status?: "loadi
         </Button>
         <Button
           className={css({
-            padding: "0.5em 0.8em"
+            padding: "0.5em 0.8em",
           })}
           disabled={selectedItems.length === 0}
           onClick={() => {
             console.log(`Delete Button Clicked`);
             console.log(selectedItems);
+            fileMutate.mutate(selectedItems);
             setSelectedItems([]);
           }}
         >
@@ -112,24 +141,30 @@ export function FileTable({data, status = null}: { data: File[], status?: "loadi
         head={[
           {
             id: 0,
-            value: "이름"
+            value: "이름",
           },
           {
             id: 1,
-            value: "업로드 시간"
-          }
+            value: "업로드 시간",
+          },
         ]}
         body={data.map((item) => {
           return {
             id: item.fileId,
             values: [
               <div key={0}>{item.name}</div>,
-              <div key={1}>{formatDate(item.createdAt, "yyyy-MM-dd HH:mm:ss")}</div>
-            ]
+              <div key={1}>
+                {formatDate(item.createdAt, "yyyy-MM-dd HH:mm:ss")}
+              </div>,
+            ],
           };
         })}
         placeholder={
-          status === null ? DataEmptyPlaceholder : (status === "loading" ? LoadingPlaceholder : ErrorPlaceholder)
+          status === null
+            ? DataEmptyPlaceholder
+            : status === "loading"
+              ? LoadingPlaceholder
+              : ErrorPlaceholder
         }
         selectedItems={selectedItems}
         setSelectedItems={setSelectedItems}

--- a/packages/front-end/components/FileUploader.tsx
+++ b/packages/front-end/components/FileUploader.tsx
@@ -39,7 +39,7 @@ export default function FileUploader({
         },
       }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["user files"] });
+      queryClient.invalidateQueries({ queryKey: ["user", "files"] });
     },
     onError: (e) => {
       console.error(e);

--- a/packages/front-end/components/FileUploader.tsx
+++ b/packages/front-end/components/FileUploader.tsx
@@ -52,7 +52,10 @@ export default function FileUploader({
       alert("파일을 선택해라");
       return;
     }
-    formData.append("file", currentFile);
+    formData.append("file",currentFile,Buffer.from(currentFile.name).toString("utf-8"));
+    for (const pair of formData.entries()) {
+      console.log(pair[0],pair[1]);
+    }
     fileMutate.mutate(formData);
   };
   return (


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가

## ❗️ 관련 이슈 [#]
close #252
close #255
## 📄 개요
- 체크된 파일을 버튼을 누르면 삭제

## 🔁 변경 사항
- mutation을 이용
- invalidate query의 querykey를 ["user","files"] 사용 (기존: ["user files"]라 대응되는 쿼리키 없었음)
- Promise.all을 이용해 선택된 데이터를 waterfall 최소화해 삭제 요청 보냄
- 삭제 성공시 -> 파일 테이블 쿼리키에 해당되는 데이터 refetch해 테이블 갱신

## 📸 동작 화면 스크린샷

## 👀 기타 논의 사항
- 콘솔로그 삭제 필요