### PR TITLE
feat: GET user/profile at sidebar

### DIFF
--- a/packages/front-end/app/(sidebar-pages)/_components/Sidebar/SidebarUser.tsx
+++ b/packages/front-end/app/(sidebar-pages)/_components/Sidebar/SidebarUser.tsx
@@ -62,6 +62,7 @@ function SidebarUser({ data }: PropType) {
         <p
           className={css({
             fontWeight: "bold",
+            alignSelf:"center"
           })}
         >
           {data.nickname}

--- a/packages/front-end/app/(sidebar-pages)/_components/Sidebar/SidebarUser.tsx
+++ b/packages/front-end/app/(sidebar-pages)/_components/Sidebar/SidebarUser.tsx
@@ -1,18 +1,31 @@
 import SidebarBaseElement from "@/app/(sidebar-pages)/_components/Sidebar/SidebarBaseElement";
-
 import { css } from "@/styled-system/css";
 import { useState, useEffect, useRef } from "react";
-
 import SidebarLink from "@/app/(sidebar-pages)/_components/Sidebar/SidebarLink";
 import Divider from "@/components/Divider";
-
-
 import SettingsIcon from "@/public/icons/settings.svg";
 import LogoutIcon from "@/public/icons/log-out.svg";
 import Image from "next/image";
+import { User } from "@/schema/backend.schema";
+import { useQuery } from "@tanstack/react-query";
+import { AxiosResponse } from "axios";
+import { apiClient } from "@/util/axios";
 
+export default function SidebarUserFetch() {
+  const { data: response, isLoading } = useQuery<AxiosResponse<User>>({
+    queryKey: ["user", "profile"],
+    queryFn: async () => await apiClient.get("/user/profile"),
+  });
+  if (isLoading) return <div>Loading...</div>;
+  const data = response?.data;
+  return data !== undefined && <SidebarUser data={data} />;
+}
 
-export default function SidebarUser() {
+interface PropType {
+  data: User;
+}
+
+function SidebarUser({ data }: PropType) {
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement | null>(null);
 
@@ -29,44 +42,71 @@ export default function SidebarUser() {
   }, []);
 
   return (
-    <div ref={menuRef} className={css({
-      position: "relative",
-      display: "inline-block",
-    })}>
+    <div
+      ref={menuRef}
+      className={css({
+        position: "relative",
+        display: "inline-block",
+      })}
+    >
       <SidebarBaseElement active={isOpen} onClick={() => setIsOpen(!isOpen)}>
-        <Image src={"/icon/logo.png"} width={32} height={32} alt="프로필 사진" />
-        <p className={css({
-          fontWeight: "bold",
-        })}>사용자 닉네임</p>
+        <Image
+          src={data.profileUrl ? data.profileUrl : "/icon/icon-google.svg"}
+          width={32}
+          height={32}
+          alt="프로필 사진"
+          className={css({
+            borderRadius: "50%",
+          })}
+        />
+        <p
+          className={css({
+            fontWeight: "bold",
+          })}
+        >
+          {data.nickname}
+        </p>
       </SidebarBaseElement>
-      {
-        isOpen
-        ?
-        <div className={css({
-          position: "absolute",
-          bottom: "100%",
-          left: "-0.3em",
-          display: "flex",
-          flexDirection: "column",
-          margin: "0.5em 0",
-          padding: "0.5em",
-          width: "calc(100% + 0.6em)",
-          backgroundColor: "#ffffff",
-          border: "1px solid #0000001a",
-          borderRadius: "0.5em",
-          boxShadow: "0 10px 15px -3px #0000001a, 0 4px 6px -4px #0000001a",
-          gap: "0.5em",
-        })}>
-          <SidebarLink href="/help" onClick={() => setIsOpen(false)} target="_blank">도움말 / 문의하기</SidebarLink>
-          <SidebarLink href="/settings" onClick={() => setIsOpen(false)}><SettingsIcon width={"1.2em"}/>설정</SidebarLink>
-          <Divider className={css({
-            margin: "unset",
-          })} />
-          <SidebarLink href="/logout"><LogoutIcon width={"1.2em"}/>로그아웃</SidebarLink>
+      {isOpen ? (
+        <div
+          className={css({
+            position: "absolute",
+            bottom: "100%",
+            left: "-0.3em",
+            display: "flex",
+            flexDirection: "column",
+            margin: "0.5em 0",
+            padding: "0.5em",
+            width: "calc(100% + 0.6em)",
+            backgroundColor: "#ffffff",
+            border: "1px solid #0000001a",
+            borderRadius: "0.5em",
+            boxShadow: "0 10px 15px -3px #0000001a, 0 4px 6px -4px #0000001a",
+            gap: "0.5em",
+          })}
+        >
+          <SidebarLink
+            href="/help"
+            onClick={() => setIsOpen(false)}
+            target="_blank"
+          >
+            도움말 / 문의하기
+          </SidebarLink>
+          <SidebarLink href="/settings" onClick={() => setIsOpen(false)}>
+            <SettingsIcon width={"1.2em"} />
+            설정
+          </SidebarLink>
+          <Divider
+            className={css({
+              margin: "unset",
+            })}
+          />
+          <SidebarLink href="/logout">
+            <LogoutIcon width={"1.2em"} />
+            로그아웃
+          </SidebarLink>
         </div>
-        :
-        null
-      }
+      ) : null}
     </div>
   );
 }

--- a/packages/front-end/app/(sidebar-pages)/_components/Sidebar/index.tsx
+++ b/packages/front-end/app/(sidebar-pages)/_components/Sidebar/index.tsx
@@ -4,22 +4,18 @@ import { css } from "@/styled-system/css";
 import SidebarGroup from "@/app/(sidebar-pages)/_components/Sidebar/SidebarGroup";
 import SidebarLink from "./SidebarLink";
 import SidebarDirectory from "./SidebarDirectory";
-import SidebarUser from "./SidebarUser";
 import Divider from "@/components/Divider";
 import { Heading } from "@/components/Text";
-import Button from "@/components/Button";
 import LinkButton from "@/components/LinkButton";
 import { useRouter } from "@/hook/useRouter";
-
 import LayoutIcon from "@/public/icons/layout.svg";
 import CastIcon from "@/public/icons/cast.svg";
 import PlusCircleIcon from "@/public/icons/plus-circle.svg";
 import ExternalLinkIcon from "@/public/icons/external-link.svg"
 import DatabaseIcon from "@/public/icons/database.svg";
-
 import Image from "next/image";
-
 import { PROJECT_NAME } from "@/const/config";
+import SidebarUserFetch from "./SidebarUser";
 
 export default function Sidebar() {
   const router = useRouter();
@@ -74,7 +70,7 @@ export default function Sidebar() {
         <SidebarLink href="/files"><DatabaseIcon width={"1.2em"}/>드라이브</SidebarLink>
       </SidebarGroup>
       <Divider/>
-      <SidebarUser/>
+      <SidebarUserFetch/>
     </div>
   );
 }


### PR DESCRIPTION
사이드바에 유저 정보

## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가

## ❗️ 관련 이슈 [#]
close #258 
## 📄 개요
- 사이드바 하단에 유저 정보 표시

## 🔁 변경 사항
- SidebarUserFetch 제작 쿼리키는 ["user","profile"]
- default profileURL은 임시적으로 구글 아이콘
- align-self 속성으로 글자가 중간에 오도록함

## 📸 동작 화면 스크린샷
![image](https://github.com/user-attachments/assets/dc974be3-95a9-4084-a246-7f433cb7893e)


## 👀 기타 논의 사항
- default image (프로필 사진 url이 이상하거나 없거나 오류나면 표시할) 제작하면 좋을듯 함