### PR TITLE
259 setting user

### DIFF
--- a/packages/front-end/app/(sidebar-pages)/sessions/join/page.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/join/page.tsx
@@ -28,7 +28,7 @@ export default function Page() {
           <LineEdit className={css({
             width: "100%",
             height: "inherit",
-          })} placeholder="세션 아이디를 입력해 주세요." text={sessionId} onChange={(event) => setSessionId(event.target.value)}/>
+          })} placeholder="세션 아이디를 입력해 주세요." value={sessionId} onChange={(event) => setSessionId(event.target.value)}/>
           <Button className={css({
             height: "inherit",
           })} disabled={sessionId === ""}>{"->"}</Button>

--- a/packages/front-end/app/(sidebar-pages)/settings/_components/UserProfileEdit.tsx
+++ b/packages/front-end/app/(sidebar-pages)/settings/_components/UserProfileEdit.tsx
@@ -15,6 +15,9 @@ interface PropType {
 export default function UserProfileEdit({ data }: PropType) {
   const fileInputRef = useRef<null | HTMLInputElement>(null);
   const formRef = useRef<null | HTMLFormElement>(null);
+  const [imageSrc, setImageSrc] = useState<string>(
+    data.profileUrl || "/icon/icon-google.svg"
+  );
   const queryClient = useQueryClient();
   const formMutation = useMutation({
     mutationFn: async (body: FormData) =>
@@ -28,6 +31,18 @@ export default function UserProfileEdit({ data }: PropType) {
     },
   });
 
+  const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = () => {
+        setImageSrc(reader.result as string);
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+
   return (
     <form
       className={css({
@@ -40,7 +55,6 @@ export default function UserProfileEdit({ data }: PropType) {
         e.preventDefault();
         if (formRef.current) {
           const formData = new FormData(formRef.current);
-          formData.append("email","temp@gmail.com");
           formMutation.mutate(formData);
         }
       }}
@@ -52,22 +66,21 @@ export default function UserProfileEdit({ data }: PropType) {
           gap: "1em",
         })}
       >
+        <Paragraph>프로필 사진</Paragraph>
         <div className={css({ display: "flex", gap: "1.5rem" })}>
-          <div>
-            <Paragraph>프로필 사진</Paragraph>
-            <Image
-              src={data.profileUrl || "/icon/icon-google.svg"}
-              alt="프로필 사진"
-              width={32}
-              height={32}
-              className={css({ borderRadius: "50%" })}
-            />
-          </div>
+          <Image
+            src={imageSrc}
+            alt="프로필 사진"
+            width={50}
+            height={50}
+            className={css({ borderRadius: "50%",height:"50px" })}
+          />
           <input
             type="file"
             accept="image/*"
             ref={fileInputRef}
             name="profileImage"
+            onChange={handleImageChange}
             hidden
           />
           <Button

--- a/packages/front-end/app/(sidebar-pages)/settings/_components/UserProfileEdit.tsx
+++ b/packages/front-end/app/(sidebar-pages)/settings/_components/UserProfileEdit.tsx
@@ -4,24 +4,42 @@ import { css } from "@/styled-system/css";
 import Image from "next/image";
 import { useState } from "react";
 import LineEdit from "@/components/LineEdit";
+import { User } from "@/schema/backend.schema";
 
+interface PropType {
+  data: User;
+}
 
-export default function UserProfileEdit(data: { displayName: string, profileImageURL: string | null }) {
-  const [displayName, setDisplayName] = useState(data.displayName);
+export default function UserProfileEdit({ data }: PropType) {
+  const [displayName, setDisplayName] = useState(data.nickname);
 
   return (
-    <div className={css({
-      display: "flex",
-      flexDirection: "column",
-      gap: "1em",
-    })}>
-      <div className={css({
+    <form
+      className={css({
         display: "flex",
+        flexDirection: "column",
         gap: "1em",
-      })}>
-        <div>
-          <Paragraph>프로필 사진</Paragraph>
-          <Image src={data.profileImageURL || ""} alt="프로필 사진"/>
+      })}
+    >
+      <div
+        className={css({
+          display: "flex",
+          flexDirection:"column",
+          gap: "1em",
+        })}
+      >
+        <div className={css({display:"flex",gap:"1.5rem"})}>
+          <div>
+            <Paragraph>프로필 사진</Paragraph>
+          <Image
+            src={data.profileUrl || "/icon/icon-google.svg"}
+            alt="프로필 사진"
+            width={32}
+            height={32}
+            className={css({ borderRadius: "50%" })}
+          />  
+          </div>
+          <Button>수정하기</Button>
         </div>
         <div>
           <Paragraph>닉네임</Paragraph>
@@ -33,6 +51,6 @@ export default function UserProfileEdit(data: { displayName: string, profileImag
         </div>
       </div>
       <Button type="submit">저장하기</Button>
-    </div>
+    </form>
   );
 }

--- a/packages/front-end/app/(sidebar-pages)/settings/_components/UserProfileEdit.tsx
+++ b/packages/front-end/app/(sidebar-pages)/settings/_components/UserProfileEdit.tsx
@@ -2,7 +2,7 @@ import Button from "@/components/Button";
 import { Paragraph } from "@/components/Text";
 import { css } from "@/styled-system/css";
 import Image from "next/image";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import LineEdit from "@/components/LineEdit";
 import { User } from "@/schema/backend.schema";
 
@@ -11,7 +11,8 @@ interface PropType {
 }
 
 export default function UserProfileEdit({ data }: PropType) {
-  const [displayName, setDisplayName] = useState(data.nickname);
+  const fileInputRef = useRef<null | HTMLInputElement>(null);
+  const formRef = useRef<null | HTMLFormElement>(null);
 
   return (
     <form
@@ -20,32 +21,49 @@ export default function UserProfileEdit({ data }: PropType) {
         flexDirection: "column",
         gap: "1em",
       })}
+      ref={formRef}
     >
       <div
         className={css({
           display: "flex",
-          flexDirection:"column",
+          flexDirection: "column",
           gap: "1em",
         })}
       >
-        <div className={css({display:"flex",gap:"1.5rem"})}>
+        <div className={css({ display: "flex", gap: "1.5rem" })}>
           <div>
             <Paragraph>프로필 사진</Paragraph>
-          <Image
-            src={data.profileUrl || "/icon/icon-google.svg"}
-            alt="프로필 사진"
-            width={32}
-            height={32}
-            className={css({ borderRadius: "50%" })}
-          />  
+            <Image
+              src={data.profileUrl || "/icon/icon-google.svg"}
+              alt="프로필 사진"
+              width={32}
+              height={32}
+              className={css({ borderRadius: "50%" })}
+            />
           </div>
-          <Button>수정하기</Button>
+          <input
+            type="file"
+            accept="image/*"
+            ref={fileInputRef}
+            name="profileImage"
+            hidden
+          />
+          <Button
+            onClick={() => {
+              if (fileInputRef.current !== null) {
+                fileInputRef.current.click();
+              }
+            }}
+          >
+            수정하기
+          </Button>
         </div>
         <div>
           <Paragraph>닉네임</Paragraph>
           <LineEdit
             placeholder="닉네임을 입력해 주세요."
-            onChange={(event) => setDisplayName(event.target.value)}
+            defaultValue={data.nickname}
+            name="nickname"
           />
         </div>
       </div>

--- a/packages/front-end/app/(sidebar-pages)/settings/_components/UserProfileEdit.tsx
+++ b/packages/front-end/app/(sidebar-pages)/settings/_components/UserProfileEdit.tsx
@@ -45,7 +45,6 @@ export default function UserProfileEdit({ data }: PropType) {
           <Paragraph>닉네임</Paragraph>
           <LineEdit
             placeholder="닉네임을 입력해 주세요."
-            text={displayName}
             onChange={(event) => setDisplayName(event.target.value)}
           />
         </div>

--- a/packages/front-end/app/(sidebar-pages)/settings/_components/UserProfileEdit.tsx
+++ b/packages/front-end/app/(sidebar-pages)/settings/_components/UserProfileEdit.tsx
@@ -5,6 +5,8 @@ import Image from "next/image";
 import { useRef, useState } from "react";
 import LineEdit from "@/components/LineEdit";
 import { User } from "@/schema/backend.schema";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiClient } from "@/util/axios";
 
 interface PropType {
   data: User;
@@ -13,6 +15,18 @@ interface PropType {
 export default function UserProfileEdit({ data }: PropType) {
   const fileInputRef = useRef<null | HTMLInputElement>(null);
   const formRef = useRef<null | HTMLFormElement>(null);
+  const queryClient = useQueryClient();
+  const formMutation = useMutation({
+    mutationFn: async (body: FormData) =>
+      await apiClient.patch("/user/profile", body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["user", "profile"] });
+      queryClient.refetchQueries({ queryKey: ["user", "profile"] });
+    },
+    onError: (e) => {
+      console.error(e);
+    },
+  });
 
   return (
     <form
@@ -22,6 +36,14 @@ export default function UserProfileEdit({ data }: PropType) {
         gap: "1em",
       })}
       ref={formRef}
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (formRef.current) {
+          const formData = new FormData(formRef.current);
+          formData.append("email","temp@gmail.com");
+          formMutation.mutate(formData);
+        }
+      }}
     >
       <div
         className={css({

--- a/packages/front-end/app/(sidebar-pages)/settings/_components/UserProfileSettings.tsx
+++ b/packages/front-end/app/(sidebar-pages)/settings/_components/UserProfileSettings.tsx
@@ -2,14 +2,15 @@ import { apiClient } from "@/util/axios";
 import { useQuery } from "@tanstack/react-query";
 import { AxiosResponse } from "axios";
 import UserProfileEdit from "@/app/(sidebar-pages)/settings/_components/UserProfileEdit";
+import { User } from "@/schema/backend.schema";
 
 export default function UserProfileSettings() {
-  const { data: response, isLoading } = useQuery<AxiosResponse<any>>({
+  const { data: response, isLoading } = useQuery<AxiosResponse<User>>({
     queryKey: ["user", "profile"],
     queryFn: async () => await apiClient.get("/user/profile"),
   });
   if (isLoading)
     return <div>Loading...</div>;
   const data = response?.data;
-  return <UserProfileEdit displayName={data.nickname} profileImageURL={data.profileUrl} />;
+  return data !== undefined && <UserProfileEdit data={data} />;
 }

--- a/packages/front-end/components/LineEdit.tsx
+++ b/packages/front-end/components/LineEdit.tsx
@@ -1,35 +1,38 @@
 import { css, cx } from "@/styled-system/css";
-import { ChangeEventHandler } from "react";
+import {
+  ChangeEventHandler,
+  DetailedHTMLProps,
+  InputHTMLAttributes,
+} from "react";
 
+interface PropType
+  extends DetailedHTMLProps<
+    InputHTMLAttributes<HTMLInputElement>,
+    HTMLInputElement
+  > {}
 
-interface PropType {
-  className?: string;
-  placeholder?: string;
-  text?: string;
-  onChange?: ChangeEventHandler<HTMLInputElement>;
+export default function LineEdit({ className, ...attr }: PropType) {
+  return (
+    <input
+      {...attr}
+      type="text"
+      className={cx(
+        className,
+        css({
+          padding: "0.5em 0.8em",
+          color: "#000000",
+          background: "#ededed",
+          borderRadius: "0.4em",
+          outline: "none",
+          transition: "all 0.2s ease-in-out",
+          _hover: {
+            background: "#dcdcdc",
+          },
+          _focus: {
+            background: "#dcdcdc",
+          },
+        })
+      )}
+    />
+  );
 }
-
-export default function LineEdit({className, placeholder, text, onChange}: PropType) {
-    return (
-        <input
-            type="text"
-            placeholder={placeholder}
-            value={text}
-            onChange={onChange}
-            className={cx(className, css({
-                padding: "0.5em 0.8em",
-                color: "#000000",
-                background: "#ededed",
-                borderRadius: "0.4em",
-                outline: "none",
-                transition: "all 0.2s ease-in-out",
-                _hover: {
-                    background: "#dcdcdc",
-                },
-                _focus: {
-                    background: "#dcdcdc",
-                }
-            }))}
-        />
-    );
-};

--- a/packages/front-end/next.config.mjs
+++ b/packages/front-end/next.config.mjs
@@ -1,5 +1,14 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'catch-up-dev-s3.s3.ap-northeast-2.amazonaws.com',
+        pathname: '/**',
+      },
+    ],
+  },
   experimental: {
     externalDir: true,
   },


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가

## ❗️ 관련 이슈 [#]
close #259 
## 📄 개요
- /settings api 연동
- 공용 컴포넌트 Props 수정
- Image가 s3의 src를 받을 수 있게 수정

## 🔁 변경 사항
### LineEdit props 변경
- input태그의 역할을 하는 LineEdit의 props를 상속을 이용해 HTMLInputElement의 attribute를 그대로 받게함
- 추후 추가적인 로직을 위한 props도 빈 {}에 작성 가능
```
interface PropType
  extends DetailedHTMLProps<
    InputHTMLAttributes<HTMLInputElement>,
    HTMLInputElement
  > {}
```
- 기본적으로 설정된 type과 스타일은 덮어쓰기를 통해 사용자가 바꿔도 적용되게 함
- type의 경우 Omit을 통해 지워도 괜찮아보임(현재 개발자가 type을 지정해도 type="text"로 지정됨), 하지만 컴포넌트 목적상 type을 text말고 다른 것으로 할 가능성은 희박하다 생각
```
   <input
      {...attr}
      type="text"
      className={cx(
        className,
        css({
          padding: "0.5em 0.8em",
          color: "#000000",
          background: "#ededed",
          borderRadius: "0.4em",
          outline: "none",
          transition: "all 0.2s ease-in-out",
          _hover: {
            background: "#dcdcdc",
          },
          _focus: {
            background: "#dcdcdc",
          },
        })
      )}
    />
```
### image src
- next/image는 보안문제로 인해 지정한 image src만 받을 수 있음
- 따라서 우리가 사용중인 s3 주소를 추가함
```
const nextConfig = {
  images: {
    remotePatterns: [
      {
        protocol: 'https',
        hostname: 'catch-up-dev-s3.s3.ap-northeast-2.amazonaws.com',
        pathname: '/**',
      },
    ],
  }, // ...생략
```
### 이미지 수정 폼
- 이미지 선택 버튼 추가: 버튼 클릭시 Ref를 연결한 hidden file input이 작동됨 -> 추후 유연한 UI custom가능
- 이미지 선택시 상태로 이미지 변경
- 데이터 patch시 다시 유저 프로필 refetch 발생
## 📸 동작 화면 스크린샷
![image](https://github.com/user-attachments/assets/d24edd9b-41c2-4242-8788-b565d991e8ce)
- 내가 지정한 로컬 이미지와 superman닉네임이 적용된 모습
## 👀 기타 논의 사항
- 추후 모든 form에 form validation을 걸어야함