### PR TITLE
287 suspense

### DIFF
--- a/packages/front-end/app/(sidebar-pages)/_components/Sidebar/index.tsx
+++ b/packages/front-end/app/(sidebar-pages)/_components/Sidebar/index.tsx
@@ -7,7 +7,7 @@ import SidebarDirectory from "./SidebarDirectory";
 import Divider from "@/components/Divider";
 import { Heading } from "@/components/Text";
 import LinkButton from "@/components/LinkButton";
-import { useRouter } from "@/hook/useRouter";
+
 import LayoutIcon from "@/public/icons/layout.svg";
 import CastIcon from "@/public/icons/cast.svg";
 import PlusCircleIcon from "@/public/icons/plus-circle.svg";
@@ -18,7 +18,6 @@ import { PROJECT_NAME } from "@/const/config";
 import SidebarUserFetch from "./SidebarUser";
 
 export default function Sidebar() {
-  const router = useRouter();
 
   return (
     <div

--- a/packages/front-end/app/(sidebar-pages)/layout.tsx
+++ b/packages/front-end/app/(sidebar-pages)/layout.tsx
@@ -1,20 +1,27 @@
-import { ReactNode } from "react";
+import { ReactNode, Suspense } from "react";
 import { css } from "@/styled-system/css";
 import Sidebar from "@/app/(sidebar-pages)/_components/Sidebar";
 
-export default function Layout({ children }: Readonly<{ children: ReactNode }>) {
-
+export default function Layout({
+  children,
+}: Readonly<{ children: ReactNode }>) {
   return (
-    <div className={css({
-      display: "flex",
-      width: "100%",
-      height: "100%",
-    })}>
-      <Sidebar/>
-      <div className={css({
-        flexGrow: 1,
-        padding: "2em 1em",
-      })}>
+    <div
+      className={css({
+        display: "flex",
+        width: "100%",
+        height: "100%",
+      })}
+    >
+      <Suspense fallback={<h1>페이지 로딩...</h1>}>
+        <Sidebar />
+      </Suspense>
+      <div
+        className={css({
+          flexGrow: 1,
+          padding: "2em 1em",
+        })}
+      >
         {children}
       </div>
     </div>

--- a/packages/front-end/app/(sidebar-pages)/sessions/host/layout.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/host/layout.tsx
@@ -1,0 +1,5 @@
+import { ReactNode, Suspense } from "react";
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return <Suspense fallback={<h1>페이지 로딩...</h1>}>{children}</Suspense>;
+}

--- a/packages/front-end/app/(sidebar-pages)/sessions/participant/layout.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/participant/layout.tsx
@@ -1,0 +1,5 @@
+import { ReactNode, Suspense } from "react";
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return <Suspense fallback={<h1>페이지 로딩...</h1>}>{children}</Suspense>;
+}

--- a/packages/front-end/app/(sidebar-pages)/settings/page.tsx
+++ b/packages/front-end/app/(sidebar-pages)/settings/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Suspense } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import Divider from "@/components/Divider";
 import { Heading } from "@/components/Text";
@@ -10,12 +9,12 @@ export default function Page() {
   return (
     <div>
       <Heading>설정</Heading>
-      <Divider/>
+      <Divider />
       <div>
-        <ErrorBoundary fallback={<h1>예기치 못한 오류가 발생하였습니다. [임시 컴포넌트]</h1>}>
-          <Suspense fallback={<h1>불러오는 중... [임시 컴포넌트]</h1>}>
-            <UserProfileSettings/>
-          </Suspense>
+        <ErrorBoundary
+          fallback={<h1>예기치 못한 오류가 발생하였습니다. [임시 컴포넌트]</h1>}
+        >
+          <UserProfileSettings />
         </ErrorBoundary>
       </div>
     </div>

--- a/packages/front-end/app/help/layout.tsx
+++ b/packages/front-end/app/help/layout.tsx
@@ -1,0 +1,5 @@
+import { ReactNode, Suspense } from "react";
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return <Suspense fallback={<h1>페이지 로딩...</h1>}>{children}</Suspense>;
+}

--- a/packages/front-end/app/logout/layout.tsx
+++ b/packages/front-end/app/logout/layout.tsx
@@ -1,0 +1,5 @@
+import { ReactNode, Suspense } from "react";
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return <Suspense fallback={<h1>페이지 로딩...</h1>}>{children}</Suspense>;
+}

--- a/packages/front-end/app/view/[sessionId]/page.tsx
+++ b/packages/front-end/app/view/[sessionId]/page.tsx
@@ -2,6 +2,6 @@
 import "./_util/pdfWorkerPolyfill";
 import PDFViewer from "./_components/PDFViewer";
 
-export default function _Page() {
+export default function Page() {
   return <PDFViewer />;
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 버그 수정

## ❗️ 관련 이슈 [#]
close #287 
## 📄 개요
- useRouter 에서 pathName을 접근한다면 부모를 Suspense로 감싸야함
- 빌드환경에서 에러 발생

## 🔁 변경 사항
- sideBar에서 useRouter적용해 임시적으로 Suspense 적용
- 사용되지 않은 useRouter 삭재
- useRouter을 사용하는 페이지에 layout에 Suspense 적용

## 📸 동작 화면 스크린샷

## 👀 기타 논의 사항
- next config에서 해당 에러를 끌 수 있음
- 만약, suspense를 사용하지 않는 경우 유저는 흰하면을 잠시동안 보게 될 것임 