### PR TITLE
feat: logout error handle

### DIFF
--- a/packages/front-end/app/logout/page.tsx
+++ b/packages/front-end/app/logout/page.tsx
@@ -2,7 +2,7 @@
 
 import { css } from "@/styled-system/css";
 import { apiClient } from "@/utils/axios";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "@/hook/useRouter";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
@@ -16,14 +16,15 @@ export default function Page() {
       router.push("/");
     },
     onError: (error) => {
-      alert(`넌 로그아웃할 수 없다:${error.message}`);
       router.push("/");
+      alert(`로그아웃 실패:${error.message}`);
     },
   });
 
   useEffect(() => {
     logoutMutate.mutate();
-  }, [logoutMutate]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div


### PR DESCRIPTION
로그아웃시 alert를 띄움

## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정

## ❗️ 관련 이슈 [#]
close #290 
## 📄 개요
- logout시 에러가 발생할떄 상황을 핸들링

## 🔁 변경 사항
### useEffect 의존성 배열 제거 및 린트 무시
```
  useEffect(() => {
    logoutMutate.mutate();
    // eslint-disable-next-line react-hooks/exhaustive-deps
  }, []);
```
- 기본적으로 logoutMutate를 의존성 배열에 넣어야함
- 하지만, logoutMutate.mutate()를 한 뒤 컴포넌트가 재실행돼 logoutMutate가 재생성돼 무한루프 발생
- 따라서 예외적+임시적으로 의존성배열 삭제
### 에러 핸들링
```
    onError: (error) => {
      router.push("/");
      alert(`로그아웃 실패:${error.message}`);
    },
```
- 루트페이지로 이동
- 이동 중 alert를 띄워줌
- default retry가 1번이므로 alert는 총 2번 발생
## 👀 기타 논의 사항
- 예외적인 useMutation이 아닌 promiseChaining을 통한 /auth/logout 처리
- 에러 ui 추후 제작(로그아웃 실패 재시도하겠습니까?)
- 로그아웃 성공시 api call 2번 발생, 두 요청이 모두 2xx인걸 봐선 strict mode로 인한 개발환경만의 이슈인걸로 생각됨