### PR TITLE
300 goto view

### DIFF
--- a/packages/front-end/app/(sidebar-pages)/sessions/detail/[sessionId]/_components/HostSession/index.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/detail/[sessionId]/_components/HostSession/index.tsx
@@ -9,12 +9,14 @@ import FileUploadAndSelectModal from "@/components/FileUploadAndSelectModal";
 import { ChangeEvent, useRef } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiClient } from "@/utils/axios";
+import { useRouter } from "@/hook/useRouter";
 
 interface PropType {
   sessionData: SessionResponseDto;
 }
 
 export default function HostSession({ sessionData }: PropType) {
+  const router = useRouter();
   const queryClient = useQueryClient();
   const formDataRef = useRef<CreateSessionDto>({
     sessionFileIds: [],
@@ -25,6 +27,8 @@ export default function HostSession({ sessionData }: PropType) {
       await apiClient.patch(`/session/${sessionData.sessionId}`, body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["user", "sessions", "host"] });
+      router.push(`/view/${sessionData.sessionId}`)
+
     },
   });
   const handleFileButtonClick = () => {

--- a/packages/front-end/app/(sidebar-pages)/sessions/detail/[sessionId]/_components/ParticipantSession/index.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/detail/[sessionId]/_components/ParticipantSession/index.tsx
@@ -1,5 +1,6 @@
 import Button from "@/components/Button";
 import { Heading, Paragraph } from "@/components/Text";
+import { useRouter } from "@/hook/useRouter";
 import { SessionResponseDto } from "@/schema/backend.schema";
 import { css } from "@/styled-system/css";
 
@@ -8,14 +9,15 @@ interface PropType {
 }
 
 export default function ParticipantSession({ sessionData }: PropType) {
+  const router = useRouter();
   return (
     <main
       className={css({
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
-        width:"100%",
-        height:"100%",
+        width: "100%",
+        height: "100%",
       })}
     >
       <div
@@ -34,7 +36,13 @@ export default function ParticipantSession({ sessionData }: PropType) {
           <Paragraph key={file.fileId}>{file.name}</Paragraph>
         ))}
         <Paragraph>파일 제목 목록</Paragraph>
-        <Button type="submit">세션 참여</Button>
+        <Button
+          onClick={() => {
+            router.push(`view/${sessionData.sessionId}`);
+          }}
+        >
+          세션 참여
+        </Button>
       </div>
     </main>
   );

--- a/packages/front-end/app/(sidebar-pages)/sessions/detail/[sessionId]/loading.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/detail/[sessionId]/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading(){
+    return <h1>로딩...</h1>
+}

--- a/packages/front-end/app/(sidebar-pages)/sessions/host/_components/HostSessionTable.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/host/_components/HostSessionTable.tsx
@@ -162,17 +162,15 @@ export function HostSessionTable({
               <div key={2}>
                 {item.closedAt ? `${item.closedAt}에 종료됨` : "진행 중"}
               </div>,
-              <Button
+              <LinkButton
                 key={3}
                 className={css({
                   padding: "0.5em 0.8em",
                 })}
-                onClick={(event) => {
-                  event.stopPropagation();
-                }}
+                href={`view/${item.sessionId}`}
               >
-                세션 참여
-              </Button>,
+                세션 시작
+              </LinkButton>,
             ],
             onClick: () => router.push(`/sessions/detail/${item.sessionId}`),
           };

--- a/packages/front-end/app/(sidebar-pages)/sessions/participant/_components/ParticipantSessionTable.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/participant/_components/ParticipantSessionTable.tsx
@@ -10,16 +10,17 @@ import { PROJECT_NAME } from "@/const/config";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiClient } from "@/utils/axios";
 
-
 const DataEmptyPlaceholder = (
-  <div className={css({
-    display: "flex",
-    padding: "1em",
-    flexDirection: "column",
-    justifyContent: "center",
-    alignItems: "center",
-    gap: "0.5em",
-  })}>
+  <div
+    className={css({
+      display: "flex",
+      padding: "1em",
+      flexDirection: "column",
+      justifyContent: "center",
+      alignItems: "center",
+      gap: "0.5em",
+    })}
+  >
     <p>표시할 데이터가 없습니다.</p>
     <p>새로운 {PROJECT_NAME} 세션에 참가해 보세요!</p>
     <LinkButton
@@ -33,36 +34,43 @@ const DataEmptyPlaceholder = (
   </div>
 );
 
-
 const LoadingPlaceholder = (
-  <div className={css({
-    display: "flex",
-    padding: "1em",
-    flexDirection: "column",
-    justifyContent: "center",
-    alignItems: "center",
-    gap: "0.5em",
-  })}>
+  <div
+    className={css({
+      display: "flex",
+      padding: "1em",
+      flexDirection: "column",
+      justifyContent: "center",
+      alignItems: "center",
+      gap: "0.5em",
+    })}
+  >
     <p>불러오는 중...</p>
   </div>
 );
 
-
 const ErrorPlaceholder = (
-  <div className={css({
-    display: "flex",
-    padding: "1em",
-    flexDirection: "column",
-    justifyContent: "center",
-    alignItems: "center",
-    gap: "0.5em",
-  })}>
+  <div
+    className={css({
+      display: "flex",
+      padding: "1em",
+      flexDirection: "column",
+      justifyContent: "center",
+      alignItems: "center",
+      gap: "0.5em",
+    })}
+  >
     <p>오류가 발생하였습니다.</p>
   </div>
 );
 
-
-export function ParticipantSessionTable({data, status = null}: { data: Session[], status?: "loading" | "error" | null }) {
+export function ParticipantSessionTable({
+  data,
+  status = null,
+}: {
+  data: Session[];
+  status?: "loading" | "error" | null;
+}) {
   const router = useRouter();
   const [selectedItems, setSelectedItems] = useState<number[]>([]);
   const queryClient = useQueryClient();
@@ -74,8 +82,12 @@ export function ParticipantSessionTable({data, status = null}: { data: Session[]
         })
       ),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["user", "sessions", "participant"] });
-      queryClient.refetchQueries({ queryKey: ["user", "sessions", "participant"] });
+      queryClient.invalidateQueries({
+        queryKey: ["user", "sessions", "participant"],
+      });
+      queryClient.refetchQueries({
+        queryKey: ["user", "sessions", "participant"],
+      });
     },
     onError: (e) => {
       console.error(e);
@@ -83,16 +95,20 @@ export function ParticipantSessionTable({data, status = null}: { data: Session[]
   });
 
   return (
-    <div className={css({
-      display: "flex",
-      flexDirection: "column",
-      gap: "0.6em",
-    })}>
-      <div className={css({
+    <div
+      className={css({
         display: "flex",
-        gap: "1em",
-        justifyContent: "flex-end",
-      })}>
+        flexDirection: "column",
+        gap: "0.6em",
+      })}
+    >
+      <div
+        className={css({
+          display: "flex",
+          gap: "1em",
+          justifyContent: "flex-end",
+        })}
+      >
         <LinkButton
           className={css({
             padding: "0.5em 0.8em",
@@ -103,7 +119,7 @@ export function ParticipantSessionTable({data, status = null}: { data: Session[]
         </LinkButton>
         <Button
           className={css({
-            padding: "0.5em 0.8em"
+            padding: "0.5em 0.8em",
           })}
           disabled={selectedItems.length === 0}
           onClick={() => {
@@ -118,7 +134,7 @@ export function ParticipantSessionTable({data, status = null}: { data: Session[]
         head={[
           {
             id: 0,
-            value: "제목"
+            value: "제목",
           },
           {
             id: 1,
@@ -137,32 +153,38 @@ export function ParticipantSessionTable({data, status = null}: { data: Session[]
             value: "빠른 작업",
             width: "10vw",
             minWidth: "8em",
-          }
+          },
         ]}
         body={data.map((item) => {
           return {
             id: item.sessionId,
             values: [
               <div key={0}>{item.sessionName}</div>,
-              <div key={1}>{formatDate(item.createdAt, "yyyy-MM-dd HH:mm:ss")}</div>,
-              <div key={2}>{item.closedAt ? `${item.closedAt}에 종료됨` : "진행 중"}</div>,
-              <Button
+              <div key={1}>
+                {formatDate(item.createdAt, "yyyy-MM-dd HH:mm:ss")}
+              </div>,
+              <div key={2}>
+                {item.closedAt ? `${item.closedAt}에 종료됨` : "진행 중"}
+              </div>,
+              <LinkButton
                 key={3}
                 className={css({
                   padding: "0.5em 0.8em",
                 })}
-                onClick={(event) => {
-                  event.stopPropagation()
-                }}
+                href={`/view/${item.sessionId}`}
               >
                 세션 참여
-              </Button>
+              </LinkButton>,
             ],
-            onClick: () => router.push(`/sessions/detail/${item.sessionId}`)
+            onClick: () => router.push(`/sessions/detail/${item.sessionId}`),
           };
         })}
         placeholder={
-          status === null ? DataEmptyPlaceholder : (status === "loading" ? LoadingPlaceholder : ErrorPlaceholder)
+          status === null
+            ? DataEmptyPlaceholder
+            : status === "loading"
+              ? LoadingPlaceholder
+              : ErrorPlaceholder
         }
         selectedItems={selectedItems}
         setSelectedItems={setSelectedItems}

--- a/packages/front-end/app/view/[sessionId]/page.tsx
+++ b/packages/front-end/app/view/[sessionId]/page.tsx
@@ -29,7 +29,7 @@ export default function Page({ params }: { params: { sessionId: string } }) {
   if (isLoading) {
     return <p>로딩...</p>;
   }
-  if (isError) {
+  if (isError || data?.fileList[0]?.url === undefined) {
     return <p>unable to load session: {params.sessionId}</p>;
   }
 

--- a/packages/front-end/app/view/[sessionId]/page.tsx
+++ b/packages/front-end/app/view/[sessionId]/page.tsx
@@ -1,40 +1,49 @@
 "use client";
 
-
 import PDFViewer from "@/components/DocumentViewer/PDF/PDFViewer";
-import {useQuery} from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { AxiosResponse } from "axios";
 import { Session, File } from "@/schema/backend.schema";
 import { apiClient } from "@/utils/axios";
 import { css } from "@/styled-system/css";
 
-
 interface SessionReturnType extends Session {
-  fileList: File[]
+  fileList: File[];
 }
 
-
 export default function Page({ params }: { params: { sessionId: string } }) {
-  const { data: response, isLoading, isError } = useQuery<AxiosResponse<SessionReturnType>>({
+  const {
+    data: response,
+    isLoading,
+    isError,
+  } = useQuery<AxiosResponse<SessionReturnType>>({
     queryKey: ["session", params.sessionId],
     queryFn: async () => {
       return await apiClient.get(`/session/${params.sessionId}`);
     },
   });
   const data = response?.data;
+  console.log("req to", `/session/${params.sessionId}`, params);
+  console.log({ data });
 
-  if (data === undefined) {
-    return <p>unable to load session: {params.sessionId}</p>
+  if (isLoading) {
+    return <p>로딩...</p>;
   }
-  const documentURL = data.fileList[0].url;
+  if (isError) {
+    return <p>unable to load session: {params.sessionId}</p>;
+  }
 
-  return (
-    <div className={css({
-      width: "100%",
-      height: "100%",
-      overflowX: "hidden",
-    })}>
-      <PDFViewer documentURL={documentURL} />
+  return data !== undefined ? (
+    <div
+      className={css({
+        width: "100%",
+        height: "100%",
+        overflowX: "hidden",
+      })}
+    >
+      <PDFViewer documentURL={data.fileList[0]?.url} />
     </div>
+  ) : (
+    <></>
   );
 }

--- a/packages/front-end/components/LinkButton.tsx
+++ b/packages/front-end/components/LinkButton.tsx
@@ -1,11 +1,10 @@
-import { useRouter } from "@/hook/useRouter";
 import Link from "next/link";
 import { ReactNode } from "react";
 import { css, cx } from "@/styled-system/css";
+import { Url } from "next/dist/shared/lib/router/router";
 
 
-export default function SidebarLink({className, children, href, target}: {className?: string, children?: ReactNode, href?: string, target?: string}) {
-  const { queryObj,pathname } = useRouter();
+export default function LinkButton({className, children, href, target}: {className?: string, children?: ReactNode, href: Url, target?: string}) {
 
   return (
     <Link className={cx(css({
@@ -24,7 +23,7 @@ export default function SidebarLink({className, children, href, target}: {classN
           background: "orange.400",
         }
       }
-    }), className)} href={{pathname: href, query: queryObj}} target={target}>
+    }), className)} href={href} target={target}>
       {children}
     </Link>
   );


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 [#]
close #300
## 📄 개요
- view/[sessionId]로 갈 수 있는 진입점 구현

## 🔁 변경 사항
### view/sessionId
- 파일 비어있을 경우 error UI
### LinkButton
- 컴포넌트 이름이 Sidebar...이라 혼란 발생, 따라서 이름을 LinkButton으로 바꿈
- href prop type이 string이고 따로 파싱해 처리하는 로직이 불필요해 LinkButton이 의존하는 next/link의 href proptype과 같은 타입 설정
  - 현재 컴포넌트상 jslogic이 없으므로 styled로 해당 컴포넌트 기술하는 것도 괜찮아 보임
### 바로가기
- 테이블에서 세션 바로가기 구현
- 세션디테일에서 세션 바로가기 구현
  - 호스트일 경우 submit이 성공하면 이동
  - 참여자일 경우 버튼 누르면 이동

## 📸 동작 화면 스크린샷

## 👀 기타 논의 사항
- 버튼 컴포넌트 변경으로 인해 테이블 폭이 좁아짐
![image](https://github.com/user-attachments/assets/4935aa7f-d557-4e24-b34c-fb40e6f19b3f)
