### PR TITLE
305 build error

### DIFF
--- a/packages/front-end/app/view/[sessionId]/page.tsx
+++ b/packages/front-end/app/view/[sessionId]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import "../../../utils/pdfWorkerPolyfill";
 import PDFViewer from "@/components/DocumentViewer/PDF/PDFViewer";
 import { useQuery } from "@tanstack/react-query";
 import { AxiosResponse } from "axios";

--- a/packages/front-end/app/view/[sessionId]/page.tsx
+++ b/packages/front-end/app/view/[sessionId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import "../../../utils/pdfWorkerPolyfill";
+import "@/utils/pdfWorkerPolyfill";
 import PDFViewer from "@/components/DocumentViewer/PDF/PDFViewer";
 import { useQuery } from "@tanstack/react-query";
 import { AxiosResponse } from "axios";

--- a/packages/front-end/app/viewer/[fileId]/page.tsx
+++ b/packages/front-end/app/viewer/[fileId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-
+import "@/utils/pdfWorkerPolyfill";
 import { useQuery } from "@tanstack/react-query";
 import { AxiosResponse } from "axios";
 import { File } from "@/schema/backend.schema";

--- a/packages/front-end/components/DocumentViewer/PDF/PDFViewer.tsx
+++ b/packages/front-end/components/DocumentViewer/PDF/PDFViewer.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState, useRef } from "react";
 import { pdfjs } from "react-pdf";
 import { Document, Page } from "react-pdf";
 import { css } from "@/styled-system/css";
-import { PDFDocumentProxy } from "pdfjs-dist/types/src/pdf";
 import "react-pdf/dist/Page/TextLayer.css";
 import "react-pdf/dist/Page/AnnotationLayer.css";
 import { useResizeObserver } from 'usehooks-ts';
@@ -38,7 +37,7 @@ export default function PDFViewer({ documentURL, defaultPageIndex = 0 }: { docum
     };
   }, [pageCount]);
 
-  const onDocumentLoadSuccess = (pdf: PDFDocumentProxy) => {
+  const onDocumentLoadSuccess = (pdf: pdfjs.PDFDocumentProxy) => {
     setPageCount(pdf.numPages);
     setCurrentPageIndex(Math.min(Math.max(0, currentPageIndex), pdf.numPages - 1));
   }

--- a/packages/front-end/utils/pdfWorkerPolyfill.ts
+++ b/packages/front-end/utils/pdfWorkerPolyfill.ts
@@ -1,0 +1,25 @@
+"use client";
+
+if (Promise.withResolvers === undefined) {
+  if (typeof window !== "undefined") {
+    // @ts-expect-error This does not exist outside of polyfill which this is doing
+    window.Promise.withResolvers = function () {
+      let resolve, reject;
+      const promise = new Promise((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+      return { promise, resolve, reject };
+    };
+  } else {
+    // @ts-expect-error This does not exist outside of polyfill which this is doing
+    global.Promise.withResolvers = function () {
+      let resolve, reject;
+      const promise = new Promise((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+      return { promise, resolve, reject };
+    };
+  }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 버그 수정

## ❗️ 관련 이슈 [#]
close #305 
## 📄 개요
- 개요 작성

## 🔁 변경 사항
### PDFDocumentProxy
```
import { pdfjs } from "react-pdf";
pdf: pdfjs.PDFDocumentProxy
```
- 직접적인 dep에서 사용
### Polyfill
- 빌드 및 개발환경에서 node 20사용해 PDFViewer컴포넌트 사용하는 페이지에서 상태코드 500 리턴
- 단, 사용시 문제는 발생하지 않음
- 현재 polyfill이 하나이므로 utils/ 에 선언

## 📸 동작 화면 스크린샷

## 👀 기타 논의 사항