### PR TITLE
feat: build-test workflow

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,11 +20,15 @@ jobs:
 
       - name: Enable Corepack
         run: corepack enable
+
       - name: Set Yarn version
         run: corepack prepare yarn@4.3.1 --activate
 
       - name: Install dependencies
         run: yarn install
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: false
+
 
       - name: Cache node_modules
         uses: actions/cache@v2

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: "20"
+          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn install
@@ -46,6 +47,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: "20"
+          cache: 'yarn'
 
       - name: Download node_modules
         uses: actions/download-artifact@v2
@@ -68,6 +70,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: "20"
+          cache: 'yarn'
 
       - name: Download node_modules
         uses: actions/download-artifact@v2

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,53 @@
+name: Build-test
+
+on:
+  pull_request:
+    branches: [ dev ]
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: yarn install
+
+  build-front-end:
+    needs: setup
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '20'
+
+      - name: Build front-end
+        run: yarn front-end run build
+
+  build-api-server:
+    needs: setup
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '20'
+
+      - name: Build api-server
+        run: yarn api-server run build

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -5,7 +5,7 @@ on:
     branches: [dev]
 
 jobs:
-  setup:
+  build-front-end:
     runs-on: ubuntu-latest
 
     steps:
@@ -30,46 +30,10 @@ jobs:
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
           YARN_ENABLE_HARDENED_MODE: 0
 
-
-      - name: Cache node_modules
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-node_modules-
-
-      - name: Upload node_modules
-        uses: actions/upload-artifact@v2
-        with:
-          name: node_modules
-          path: node_modules
-
-  build-front-end:
-    needs: setup
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: "20"
-          cache: 'yarn'
-
-      - name: Download node_modules
-        uses: actions/download-artifact@v2
-        with:
-          name: node_modules
-          path: node_modules
-
       - name: Build front-end
         run: yarn front-end run build
 
   build-api-server:
-    needs: setup
     runs-on: ubuntu-latest
 
     steps:
@@ -82,11 +46,17 @@ jobs:
           node-version: "20"
           cache: 'yarn'
 
-      - name: Download node_modules
-        uses: actions/download-artifact@v2
-        with:
-          name: node_modules
-          path: node_modules
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Set Yarn version
+        run: corepack prepare yarn@4.3.1 --activate
+
+      - name: Install dependencies
+        run: yarn install
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: false
+          YARN_ENABLE_HARDENED_MODE: 0
 
       - name: Build api-server
         run: yarn api-server run build

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -31,7 +31,7 @@ jobs:
           YARN_ENABLE_HARDENED_MODE: 0
       
       - name: Gen panda-css styles
-        run: yarn prepare
+        run: yarn front-end run prepare
 
       - name: Build front-end
         run: yarn front-end run build

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,8 +18,10 @@ jobs:
           node-version: "20"
           cache: 'yarn'
 
-      - name: Install weird dependency
-        run: yarn add json5@^2.2.2
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Set Yarn version
+        run: corepack prepare yarn@4.3.1 --activate
 
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,7 +19,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --immutable
 
       - name: Cache node_modules
         uses: actions/cache@v2

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -3,6 +3,7 @@ name: Build-test
 on:
   pull_request:
     branches: [dev]
+    types: ['opened']
 
 jobs:
   build-front-end:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,8 +18,11 @@ jobs:
           node-version: "20"
           cache: 'yarn'
 
+      - name: Install weird dependency
+        run: yarn add json5@^2.2.2
+
       - name: Install dependencies
-        run: yarn install --immutable
+        run: yarn install
 
       - name: Cache node_modules
         uses: actions/cache@v2

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -28,6 +28,7 @@ jobs:
         run: yarn install
         env:
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
+          YARN_ENABLE_HARDENED_MODE: 0
 
 
       - name: Cache node_modules

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,7 +2,7 @@ name: Build-test
 
 on:
   pull_request:
-    branches: [ dev ]
+    branches: [dev]
 
 jobs:
   setup:
@@ -15,10 +15,24 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '20'
+          node-version: "20"
 
       - name: Install dependencies
         run: yarn install
+
+      - name: Cache node_modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node_modules-
+
+      - name: Upload node_modules
+        uses: actions/upload-artifact@v2
+        with:
+          name: node_modules
+          path: node_modules
 
   build-front-end:
     needs: setup
@@ -31,7 +45,13 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '20'
+          node-version: "20"
+
+      - name: Download node_modules
+        uses: actions/download-artifact@v2
+        with:
+          name: node_modules
+          path: node_modules
 
       - name: Build front-end
         run: yarn front-end run build
@@ -47,7 +67,13 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '20'
+          node-version: "20"
+
+      - name: Download node_modules
+        uses: actions/download-artifact@v2
+        with:
+          name: node_modules
+          path: node_modules
 
       - name: Build api-server
         run: yarn api-server run build

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,6 +29,9 @@ jobs:
         env:
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
           YARN_ENABLE_HARDENED_MODE: 0
+      
+      - name: Gen panda-css styles
+        run: yarn prepare
 
       - name: Build front-end
         run: yarn front-end run build

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,4 @@
 nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.3.1.cjs
+checksumBehavior: "update"

--- a/package.json
+++ b/package.json
@@ -18,8 +18,5 @@
   "devDependencies": {
     "typescript": "^5.5.3"
   },
-  "packageManager": "yarn@4.3.1",
-  "resolutions": {
-    "json5": "^2.2.2"
-  }
+  "packageManager": "yarn@4.3.1"
 }

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
   "devDependencies": {
     "typescript": "^5.5.3"
   },
-  "packageManager": "yarn@4.3.1"
+  "packageManager": "yarn@4.3.1",
+  "resolutions": {
+    "json5": "^2.2.2"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13975,7 +13975,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json5@npm:^1.0.2, json5@npm:^2.1.2, json5@npm:^2.2.2":
+"json5@npm:^1.0.2, json5@npm:^2.2.2":
   version: 1.0.2
   resolution: "json5@npm:1.0.2"
   dependencies:
@@ -13986,7 +13986,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json5@npm:^2.2.3":
+"json5@npm:^2.1.2, json5@npm:^2.2.3":
   version: 2.2.3
   resolution: "json5@npm:2.2.3"
   bin:


### PR DESCRIPTION
프론트엔드와 api-server을 병합 전 빌드

## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## ❗️ 관련 이슈 [#]
close #309 
## 📄 개요
- dev에 PR이 머지되기 전 branch에서 백엔드와 프론트엔드를 빌드

## 🔁 변경 사항
- 프론트엔드와 백엔드 각각 의존성 설치 및 빌드
  - 의존성 설치 후 아티팩트로 업로드한걸 받아온 뒤 빌드하는 것은 시간이 너무 오래걸림
- node version과 yarn version을 우리 프로젝트와 동일하게 유지
- YARN_ENABLE_HARDENED_MODE 해제, 보안악화 및 속도 상승 -> 기타 논의 사항 링크 참고, json5 ghost dep version mapping 으로 인한 해결하지 못한 버그 존재
## 📸 동작 화면 스크린샷
- 커밋해야 압니다 
## 👀 기타 논의 사항
- [이 오류](https://stackoverflow.com/questions/78847630/github-actions-yarn-invalid-resolution-json5npm2-2-2-%e2%86%92-npm1-0-2)를 어떻게 해결할지 모르겠음
- 왜 panda css codegen 스크립트를 두번 돌려야하는걸까? -> build script에 포함돼 있으나, next build작업에 codegen한 결과물을 찾지 못함