### PR TITLE
312 join

### DIFF
--- a/packages/front-end/app/(sidebar-pages)/sessions/detail/[sessionId]/_components/ParticipantSession/index.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/detail/[sessionId]/_components/ParticipantSession/index.tsx
@@ -38,7 +38,7 @@ export default function ParticipantSession({ sessionData }: PropType) {
         <Paragraph>파일 제목 목록</Paragraph>
         <Button
           onClick={() => {
-            router.push(`view/${sessionData.sessionId}`);
+            router.push(`/view/${sessionData.sessionId}`);
           }}
         >
           세션 참여

--- a/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import "@/utils/pdfWorkerPolyfill";
+import PDFViewer from "@/components/DocumentViewer/PDF/PDFViewer";
+import { useQuery } from "@tanstack/react-query";
+import { AxiosResponse } from "axios";
+import { Session, File } from "@/schema/backend.schema";
+import { apiClient } from "@/utils/axios";
+import { css } from "@/styled-system/css";
+import { Tldraw } from "tldraw";
+
+interface SessionReturnType extends Session {
+  fileList: File[];
+}
+
+export default function HostViewer({ params }: { params: { sessionId: string } }) {
+  const {
+    data: response,
+    isLoading,
+    isError,
+  } = useQuery<AxiosResponse<SessionReturnType>>({
+    queryKey: ["session", params.sessionId],
+    queryFn: async () => {
+      return await apiClient.get(`/session/${params.sessionId}`);
+    },
+  });
+  const data = response?.data;
+  console.log("req to", `/session/${params.sessionId}`, params);
+  console.log({ data });
+
+  if (isLoading) {
+    return <p>로딩...</p>;
+  }
+  if (isError || data?.fileList[0]?.url === undefined) {
+    return <p>unable to load session: {params.sessionId}</p>;
+  }
+
+  return data !== undefined ? (
+    <div
+      className={css({
+        width: "100%",
+        height: "100%",
+        overflowX: "hidden",
+      })}
+    >
+      <PDFViewer documentURL={data.fileList[0]?.url} />
+      <div className={css({ width: "100%", position: "absolute", inset: 0 })}>
+        <Tldraw />
+      </div>
+    </div>
+  ) : (
+    <></>
+  );
+}

--- a/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
@@ -22,7 +22,7 @@ export default function ParticipantViewer({
   const joinQuery = useQuery<AxiosResponse<any>>({
     queryKey: ["user", "session", params.sessionId, "join"],
     queryFn: async () => {
-      return await apiClient.post(`/user/session/${params.sessionId}/join`);
+      return await apiClient.post(`/user/sessions/${params.sessionId}/join`);
     },
   });
   const {

--- a/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
@@ -22,7 +22,7 @@ export default function ParticipantViewer({
   const joinQuery = useQuery<AxiosResponse<any>>({
     queryKey: ["user", "session", params.sessionId, "join"],
     queryFn: async () => {
-      return await apiClient.post(`/user/sessions/${params.sessionId}/join`);
+      return await apiClient.post(`/user/session/${params.sessionId}/join`);
     },
   });
   const {

--- a/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
@@ -34,6 +34,7 @@ export default function ParticipantViewer({
     queryFn: async () => {
       return await apiClient.get(`/session/${params.sessionId}`);
     },
+    enabled: !!joinQuery.data,
   });
   const data = response?.data;
   console.log("req to", `/session/${params.sessionId}`, params);

--- a/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
@@ -13,9 +13,18 @@ interface SessionReturnType extends Session {
   fileList: File[];
 }
 
-export default function ParticipantViewer({ params }: { params: { sessionId: string } }) {
-    // user/session/:sessionId/join
-
+export default function ParticipantViewer({
+  params,
+}: {
+  params: { sessionId: string };
+}) {
+  // user/session/:sessionId/join
+  const joinQuery = useQuery<AxiosResponse<any>>({
+    queryKey: ["user", "session", params.sessionId, "join"],
+    queryFn: async () => {
+      return await apiClient.post(`/user/session/${params.sessionId}/join`);
+    },
+  });
   const {
     data: response,
     isLoading,
@@ -30,10 +39,10 @@ export default function ParticipantViewer({ params }: { params: { sessionId: str
   console.log("req to", `/session/${params.sessionId}`, params);
   console.log({ data });
 
-  if (isLoading) {
+  if (isLoading || joinQuery.isLoading) {
     return <p>로딩...</p>;
   }
-  if (isError || data?.fileList[0]?.url === undefined) {
+  if (joinQuery.isError || isError || data?.fileList[0]?.url === undefined) {
     return <p>unable to load session: {params.sessionId}</p>;
   }
 

--- a/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import "@/utils/pdfWorkerPolyfill";
+import PDFViewer from "@/components/DocumentViewer/PDF/PDFViewer";
+import { useQuery } from "@tanstack/react-query";
+import { AxiosResponse } from "axios";
+import { Session, File } from "@/schema/backend.schema";
+import { apiClient } from "@/utils/axios";
+import { css } from "@/styled-system/css";
+import { Tldraw } from "tldraw";
+
+interface SessionReturnType extends Session {
+  fileList: File[];
+}
+
+export default function ParticipantViewer({ params }: { params: { sessionId: string } }) {
+    // user/session/:sessionId/join
+
+  const {
+    data: response,
+    isLoading,
+    isError,
+  } = useQuery<AxiosResponse<SessionReturnType>>({
+    queryKey: ["session", params.sessionId],
+    queryFn: async () => {
+      return await apiClient.get(`/session/${params.sessionId}`);
+    },
+  });
+  const data = response?.data;
+  console.log("req to", `/session/${params.sessionId}`, params);
+  console.log({ data });
+
+  if (isLoading) {
+    return <p>로딩...</p>;
+  }
+  if (isError || data?.fileList[0]?.url === undefined) {
+    return <p>unable to load session: {params.sessionId}</p>;
+  }
+
+  return data !== undefined ? (
+    <div
+      className={css({
+        width: "100%",
+        height: "100%",
+        overflowX: "hidden",
+      })}
+    >
+      <PDFViewer documentURL={data.fileList[0]?.url} />
+      <div className={css({ width: "100%", position: "absolute", inset: 0 })}>
+        <Tldraw />
+      </div>
+    </div>
+  ) : (
+    <></>
+  );
+}

--- a/packages/front-end/app/view/[sessionId]/error.tsx
+++ b/packages/front-end/app/view/[sessionId]/error.tsx
@@ -1,0 +1,10 @@
+"use client";
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return <h1>{error.message}</h1>;
+}

--- a/packages/front-end/app/view/[sessionId]/page.tsx
+++ b/packages/front-end/app/view/[sessionId]/page.tsx
@@ -1,54 +1,40 @@
 "use client";
 
 import "@/utils/pdfWorkerPolyfill";
-import PDFViewer from "@/components/DocumentViewer/PDF/PDFViewer";
-import { useQuery } from "@tanstack/react-query";
-import { AxiosResponse } from "axios";
-import { Session, File } from "@/schema/backend.schema";
+import { User, SessionResponseDto } from "@/schema/backend.schema";
+import HostViewer from "./_components/HostViewer";
+import { useQueries } from "@tanstack/react-query";
 import { apiClient } from "@/utils/axios";
-import { css } from "@/styled-system/css";
-import { Tldraw } from "tldraw";
-
-interface SessionReturnType extends Session {
-  fileList: File[];
-}
+import ParticipantViewer from "./_components/ParticipantViewer";
 
 export default function Page({ params }: { params: { sessionId: string } }) {
-  const {
-    data: response,
-    isLoading,
-    isError,
-  } = useQuery<AxiosResponse<SessionReturnType>>({
-    queryKey: ["session", params.sessionId],
-    queryFn: async () => {
-      return await apiClient.get(`/session/${params.sessionId}`);
-    },
+  const [userQuery, sessionQuery] = useQueries({
+    queries: [
+      {
+        queryKey: ["user", "profile"],
+        queryFn: async () => await apiClient.get<User>("/user/profile"),
+        throwOnError: true,
+      },
+      {
+        queryKey: ["session", params.sessionId],
+        queryFn: async () =>
+          await apiClient.get<SessionResponseDto>(
+            `/session/${params.sessionId}`
+          ),
+        throwOnError: true,
+      },
+    ],
   });
-  const data = response?.data;
-  console.log("req to", `/session/${params.sessionId}`, params);
-  console.log({ data });
-
-  if (isLoading) {
-    return <p>로딩...</p>;
+  if (userQuery.isLoading || sessionQuery.isLoading) {
+    return <h1>로딩...</h1>;
   }
-  if (isError || data?.fileList[0]?.url === undefined) {
-    return <p>unable to load session: {params.sessionId}</p>;
-  }
+  const userData = userQuery.data?.data;
+  const sessionData = sessionQuery.data?.data;
+  const isHost = userData?.userId === sessionData?.hostId;
 
-  return data !== undefined ? (
-    <div
-      className={css({
-        width: "100%",
-        height: "100%",
-        overflowX: "hidden",
-      })}
-    >
-      <PDFViewer documentURL={data.fileList[0]?.url} />
-      <div className={css({ width: "100%", position: "absolute", inset: 0 })}>
-        <Tldraw />
-      </div>
-    </div>
+  return isHost ? (
+    <HostViewer params={params} />
   ) : (
-    <></>
+    <ParticipantViewer params={params} />
   );
 }

--- a/packages/front-end/app/view/[sessionId]/page.tsx
+++ b/packages/front-end/app/view/[sessionId]/page.tsx
@@ -31,7 +31,6 @@ export default function Page({ params }: { params: { sessionId: string } }) {
   const userData = userQuery.data?.data;
   const sessionData = sessionQuery.data?.data;
   const isHost = userData?.userId === sessionData?.hostId;
-
   return isHost ? (
     <HostViewer params={params} />
   ) : (

--- a/packages/front-end/next.config.mjs
+++ b/packages/front-end/next.config.mjs
@@ -3,9 +3,14 @@ const nextConfig = {
   images: {
     remotePatterns: [
       {
-        protocol: 'https',
-        hostname: 'catch-up-dev-s3.s3.ap-northeast-2.amazonaws.com',
-        pathname: '/**',
+        protocol: "https",
+        hostname: "catch-up-dev-s3.s3.ap-northeast-2.amazonaws.com",
+        pathname: "/**",
+      },
+      {
+        protocol: "http",
+        hostname: "k.kakaocdn.net",
+        pathname: "/**",
       },
     ],
   },


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가

## ❗️ 관련 이슈 [#]
close #312
## 📄 개요
- 유저가 어떤 세션의 호스트인지 아닌지 판별
- 호스트가 아니라면 POST user/session/sessionId/join 호출

## 🔁 변경 사항
- user정보와 sessionId에 대한 session정보를 fetch
  - 어차피 이전 과정에서 대부분 캐싱돼있어 여러번 호출해도 상관없음
- 해당 데이터를 이용해 유저가 세션의 호스트인지 판별
- 만약 호스트라면 <HostView/>
- 만약 참가자라면 <ParticipantView/> 
  - 참가자라면 POST join
  - enable option으로 인한 GET session/:sessionId waterfall 발생 -> 따라서 세션 정보를 가져오기전에(대부분 상황에서 캐싱된 상태) join을 통해 table relation 생성

## 📸 동작 화면 스크린샷

## 👀 기타 논의 사항
- 만약, 적절한 캐싱타임을 정해주지 않는다면 중복된 api call이 여러번 발생하겠지요