### PR TITLE
feat: change layout

### DIFF
--- a/packages/front-end/app/(sidebar-pages)/_components/Sidebar/SidebarUser.tsx
+++ b/packages/front-end/app/(sidebar-pages)/_components/Sidebar/SidebarUser.tsx
@@ -10,6 +10,7 @@ import { User } from "@/schema/backend.schema";
 import { useQuery } from "@tanstack/react-query";
 import { AxiosResponse } from "axios";
 import { apiClient } from "@/utils/axios";
+import { Paragraph } from "@/components/Text";
 
 export default function SidebarUserFetch() {
   const { data: response, isLoading } = useQuery<AxiosResponse<User>>({
@@ -49,6 +50,7 @@ function SidebarUser({ data }: PropType) {
         display: "inline-block",
       })}
     >
+      <Paragraph variant="sub3">유저</Paragraph>
       <SidebarBaseElement active={isOpen} onClick={() => setIsOpen(!isOpen)}>
         <Image
           src={data.profileUrl ? data.profileUrl : "/icon/icon-google.svg"}
@@ -57,12 +59,14 @@ function SidebarUser({ data }: PropType) {
           alt="프로필 사진"
           className={css({
             borderRadius: "50%",
+            width:"32px",
+            height:"32px",
           })}
         />
         <p
           className={css({
             fontWeight: "bold",
-            alignSelf:"center"
+            alignSelf: "center",
           })}
         >
           {data.nickname}

--- a/packages/front-end/app/(sidebar-pages)/_components/Sidebar/index.tsx
+++ b/packages/front-end/app/(sidebar-pages)/_components/Sidebar/index.tsx
@@ -43,17 +43,8 @@ export default function Sidebar() {
           alignItems: "center",
           gap: "0.5em",
         })}>
-          <Image alt={PROJECT_NAME} src="/icon/logo.png" width={40} height={40}/>
           <Heading variant="h4">{PROJECT_NAME}</Heading>
         </div>
-        <LinkButton
-          className={css({
-            fontWeight: "bold",
-          })}
-          href="/sessions/join"
-        >
-          세션 생성
-        </LinkButton>
       </div>
       <Divider/>
       <SidebarGroup name="메뉴" className={css({

--- a/packages/front-end/app/(sidebar-pages)/files/page.tsx
+++ b/packages/front-end/app/(sidebar-pages)/files/page.tsx
@@ -10,6 +10,7 @@ export default function Page() {
   return (
     <div>
       <Heading>드라이브</Heading>
+      <Heading variant="sub5">내가 업로드한 파일, 표의 항목을 클릭하면 미리보기</Heading>
       <Divider/>
       <FileTableFetcher />
     </div>

--- a/packages/front-end/app/(sidebar-pages)/sessions/create/_components/SessionCreateForm.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/create/_components/SessionCreateForm.tsx
@@ -1,9 +1,12 @@
 import Button from "@/components/Button";
 import FileUploadAndSelectModal from "@/components/FileUploadAndSelectModal";
+import { Label } from "@/components/Label";
+import LineEdit from "@/components/LineEdit";
 import ModalContainer from "@/components/ModalContainer";
 import { Paragraph } from "@/components/Text";
 import { CreateSessionDto } from "@/schema/backend.schema";
 import { css } from "@/styled-system/css";
+import { styled } from "@/styled-system/jsx";
 import { apiClient } from "@/utils/axios";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { overlay } from "overlay-kit";
@@ -35,33 +38,43 @@ export default function SessionCreateForm() {
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     formDataRef.current.sessionName = e.target.value;
   };
+
   return (
     <form
-      className={css({ display: "flex", flexDirection: "column", gap: "1rem" })}
+      className={css({
+        display: "flex",
+        flexDirection: "column",
+        gap: "1rem",
+        width: "800px",
+      })}
       onSubmit={(e) => {
         e.preventDefault();
         formMutation.mutate(formDataRef.current);
       }}
     >
-      <label htmlFor="session title">세션 제목</label>
-      <input
+      <Label htmlFor="session title">세션 제목</Label>
+      <LineEdit
         id="session title"
         name="session title"
-        placeholder="세션 제목 입력"
+        placeholder="세션 제목을 입력해주세요"
         onChange={handleInputChange}
+        className={css({ height: "50px" })}
       />
-      <label htmlFor="select file">강의 자료 선택</label>
+      <Label htmlFor="select file">강의 자료 선택</Label>
       <Button
         id="select file"
         name="select file"
         type="button"
         onClick={handleFileButtonClick}
+        className={css({ height: "50px", width: "200px",backgroundColor:"green.600" })}
       >
         자료 선택
       </Button>
-      <label>현재 선택한 파일</label>
-      <Paragraph>파일 제목 목록</Paragraph>
-      <Button type="submit">세션 시작</Button>
+      <Label>현재 선택한 파일</Label>
+      <Paragraph>선택한 파일이 없습니다.</Paragraph>
+      <Button type="submit" className={css({ height: "50px" })}>
+        세션 시작
+      </Button>
     </form>
   );
 }

--- a/packages/front-end/app/(sidebar-pages)/sessions/create/page.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/create/page.tsx
@@ -3,13 +3,25 @@
 import { Heading } from "@/components/Text";
 import Divider from "@/components/Divider";
 import SessionCreateForm from "./_components/SessionCreateForm";
+import { css } from "@/styled-system/css";
 
 export default function Page() {
   return (
-    <>
+    <div className={css({ display: "flex", flexDirection: "column",height:"100%" })}>
       <Heading>세션 생성</Heading>
+      <Heading variant="sub5">세션을 만들기위한 정보 설정</Heading>
       <Divider />
-      <SessionCreateForm />
-    </>
+      <div
+        className={css({
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          flexGrow: 1,
+        })}
+      >
+        <SessionCreateForm />
+      </div>
+    </div>
   );
 }

--- a/packages/front-end/app/(sidebar-pages)/sessions/detail/[sessionId]/_components/HostSession/index.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/detail/[sessionId]/_components/HostSession/index.tsx
@@ -1,6 +1,6 @@
 import Button from "@/components/Button";
 import ModalContainer from "@/components/ModalContainer";
-import { Heading, Paragraph } from "@/components/Text";
+import { Paragraph } from "@/components/Text";
 import { css } from "@/styled-system/css";
 import { overlay } from "overlay-kit";
 
@@ -10,6 +10,8 @@ import { ChangeEvent, useRef } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiClient } from "@/utils/axios";
 import { useRouter } from "@/hook/useRouter";
+import { Label } from "@/components/Label";
+import LineEdit from "@/components/LineEdit";
 
 interface PropType {
   sessionData: SessionResponseDto;
@@ -27,8 +29,7 @@ export default function HostSession({ sessionData }: PropType) {
       await apiClient.patch(`/session/${sessionData.sessionId}`, body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["user", "sessions", "host"] });
-      router.push(`/view/${sessionData.sessionId}`)
-
+      router.push(`/view/${sessionData.sessionId}`);
     },
   });
   const handleFileButtonClick = () => {
@@ -45,52 +46,48 @@ export default function HostSession({ sessionData }: PropType) {
     formDataRef.current.sessionName = e.target.value;
   };
   return (
-    <main
+    <form
       className={css({
         display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        width: "100%",
-        height: "100%",
+        flexDirection: "column",
+        gap: "1rem",
+        width: "800px",
       })}
+      onSubmit={(e) => {
+        e.preventDefault();
+        formMutation.mutate(formDataRef.current);
+      }}
     >
-      <form
+      <Label htmlFor="session title">세션 제목</Label>
+      <LineEdit
+        id="session title"
+        name="session title"
+        placeholder="세션 제목 입력"
+        defaultValue={formDataRef.current.sessionName}
+        onChange={handleInputChange}
+        className={css({ height: "50px" })}
+      />
+      <Label htmlFor="select file">강의 자료 선택</Label>
+      <Button
+        id="select file"
+        name="select file"
+        type="button"
+        onClick={handleFileButtonClick}
         className={css({
-          display: "flex",
-          flexDirection: "column",
-          width: "600px",
-          gap: "1rem",
+          height: "50px",
+          width: "200px",
+          backgroundColor: "green.600",
         })}
-        onSubmit={(e) => {
-          e.preventDefault();
-          formMutation.mutate(formDataRef.current);
-        }}
       >
-        <Heading>세션 정보 및 작성</Heading>
-        <label htmlFor="session title">세션 제목</label>
-        <input
-          id="session title"
-          name="session title"
-          placeholder="세션 제목 입력"
-          defaultValue={formDataRef.current.sessionName}
-          onChange={handleInputChange}
-        />
-        <label htmlFor="select file">강의 자료 선택</label>
-        <Button
-          id="select file"
-          name="select file"
-          type="button"
-          onClick={handleFileButtonClick}
-        >
-          자료 선택
-        </Button>
-        <label>현재 선택한 파일</label>
-        {sessionData.fileList.map((file) => (
-          <Paragraph key={file.fileId}>{file.name}</Paragraph>
-        ))}
-        <Paragraph>파일 제목 목록</Paragraph>
-        <Button type="submit">세션 시작</Button>
-      </form>
-    </main>
+        자료 선택
+      </Button>
+      <Label>현재 선택한 파일</Label>
+      {sessionData.fileList.map((file) => (
+        <Paragraph key={file.fileId}>{file.name}</Paragraph>
+      ))}
+      <Button type="submit" className={css({ height: "50px" })}>
+        세션 시작
+      </Button>
+    </form>
   );
 }

--- a/packages/front-end/app/(sidebar-pages)/sessions/detail/[sessionId]/_components/ParticipantSession/index.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/detail/[sessionId]/_components/ParticipantSession/index.tsx
@@ -1,4 +1,5 @@
 import Button from "@/components/Button";
+import { Label } from "@/components/Label";
 import { Heading, Paragraph } from "@/components/Text";
 import { useRouter } from "@/hook/useRouter";
 import { SessionResponseDto } from "@/schema/backend.schema";
@@ -11,39 +12,27 @@ interface PropType {
 export default function ParticipantSession({ sessionData }: PropType) {
   const router = useRouter();
   return (
-    <main
+    <div
       className={css({
         display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        width: "100%",
-        height: "100%",
+        flexDirection: "column",
+        gap: "1rem",
+        width: "800px",
       })}
     >
-      <div
-        className={css({
-          display: "flex",
-          flexDirection: "column",
-          width: "600px",
-          gap: "1rem",
-        })}
-      >
-        <Heading>세션 정보 및 작성</Heading>
-        <Paragraph>세션 제목</Paragraph>
-        <Paragraph>{sessionData.sessionName}</Paragraph>
-        <Paragraph>현재 선택한 파일</Paragraph>
-        {sessionData.fileList.map((file) => (
-          <Paragraph key={file.fileId}>{file.name}</Paragraph>
-        ))}
-        <Paragraph>파일 제목 목록</Paragraph>
-        <Button
-          onClick={() => {
+      <Label>세션 제목</Label>
+      <Paragraph className={css({ height: "50px" })}>
+        {sessionData.sessionName}
+      </Paragraph>
+      <Label>현재 선택한 파일</Label>
+      {sessionData.fileList.map((file) => (
+        <Paragraph key={file.fileId}>{file.name}</Paragraph>
+      ))}
+      <Button className={css({ height: "50px" })}           onClick={() => {
             router.push(`/view/${sessionData.sessionId}`);
-          }}
-        >
-          세션 참여
-        </Button>
-      </div>
-    </main>
+          }}>
+        세션 참여
+      </Button>
+    </div>
   );
 }

--- a/packages/front-end/app/(sidebar-pages)/sessions/detail/[sessionId]/page.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/detail/[sessionId]/page.tsx
@@ -5,6 +5,9 @@ import { useQueries } from "@tanstack/react-query";
 import HostSession from "./_components/HostSession";
 import { SessionResponseDto, User } from "@/schema/backend.schema";
 import ParticipantSession from "./_components/ParticipantSession";
+import { css } from "@/styled-system/css";
+import { Heading } from "@/components/Text";
+import Divider from "@/components/Divider";
 
 interface PropType {
   params: { sessionId: string };
@@ -35,14 +38,38 @@ export default function Page({ params }: PropType) {
   }
   const sessionData = sessionRes?.data;
   const userData = userRes?.data;
+  const isHost = userData?.userId === sessionData?.hostId;
 
   return (
-    sessionData !== undefined &&
-    userData !== undefined &&
-    (userData.userId === sessionData.hostId ? (
-      <HostSession sessionData={sessionData} />
-    ) : (
-      <ParticipantSession sessionData={sessionData} />
-    ))
+    <div
+      className={css({
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+      })}
+    >
+      <Heading>{isHost ? "세션 정보 & 수정" : "세션 정보"}</Heading>
+      <Heading variant="sub5">
+        {isHost ? "세션 시작시 수정 정보 반영" : "세션의 상세 정보"}
+      </Heading>
+      <Divider />
+      <div
+        className={css({
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          flexGrow: 1,
+        })}
+      >
+        {sessionData !== undefined &&
+          userData !== undefined &&
+          (isHost ? (
+            <HostSession sessionData={sessionData} />
+          ) : (
+            <ParticipantSession sessionData={sessionData} />
+          ))}
+      </div>
+    </div>
   );
 }

--- a/packages/front-end/app/(sidebar-pages)/sessions/host/page.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/host/page.tsx
@@ -9,6 +9,7 @@ export default function Page() {
   return (
     <>
       <Heading>내가 주최한 세션</Heading>
+      <Heading variant="sub5">표의 항목을 클릭하여 상세보기 & 수정</Heading>
       <Divider/>
       <HostSessionTableFetcher />
     </>

--- a/packages/front-end/app/(sidebar-pages)/sessions/join/loading.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/join/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <h1>로딩...</h1>;
+}

--- a/packages/front-end/app/(sidebar-pages)/sessions/join/page.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/join/page.tsx
@@ -6,32 +6,70 @@ import { Heading, Paragraph } from "@/components/Text";
 import { css } from "@/styled-system/css";
 import Button from "@/components/Button";
 import Divider from "@/components/Divider";
+import { Label } from "@/components/Label";
+import { useRouter } from "@/hook/useRouter";
 
 export default function Page() {
   const [sessionId, setSessionId] = useState("");
+  const router = useRouter();
   return (
-    <div className={css({
-      height: "100%",
-    })}>
+    <div
+      className={css({
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+      })}
+    >
       <Heading>세션 접속하기</Heading>
-      <Divider/>
-      <div className={css({
-        margin: "10em 0",
-      })}>
-        <Paragraph variant="body3" className={css({
-          marginBottom: "0.5em",
-        })}>세션 아이디</Paragraph>
-        <div className={css({
+      <Heading variant="sub5">참여코드 입력해 세션 접속</Heading>
+      <Divider />
+      <div
+        className={css({
           display: "flex",
-          gap: "0.5em",
-        })}>
-          <LineEdit className={css({
-            width: "100%",
-            height: "inherit",
-          })} placeholder="세션 아이디를 입력해 주세요." value={sessionId} onChange={(event) => setSessionId(event.target.value)}/>
-          <Button className={css({
-            height: "inherit",
-          })} disabled={sessionId === ""}>{"->"}</Button>
+          alignItems: "center",
+          flexGrow: 1,
+          justifyContent: "center",
+        })}
+      >
+        <div
+          className={css({
+            width: "800px",
+            display: "flex",
+            flexDirection: "column",
+            gap: "1rem",
+          })}
+        >
+          <Label htmlFor="session-code">세션 코드</Label>
+          <div
+            className={css({
+              display: "flex",
+              gap: "0.5em",
+            })}
+          >
+            <LineEdit
+              className={css({
+                flexGrow: 1,
+                height: "inherit",
+              })}
+              placeholder="세션 아이디를 입력해 주세요."
+              value={sessionId}
+              onChange={(event) => setSessionId(event.target.value)}
+              name="session-code"
+              id="session-code"
+            />
+            <Button
+              className={css({
+                height: "inherit",
+                minWidth: "120px",
+              })}
+              disabled={sessionId === ""}
+              onClick={()=>{
+                router.push(`/view/${sessionId}`)
+              }}
+            >
+              {"접속하기"}
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/front-end/app/(sidebar-pages)/sessions/participant/page.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/participant/page.tsx
@@ -9,6 +9,7 @@ export default function Page() {
   return (
     <>
       <Heading>내가 참가한 세션</Heading>
+      <Heading variant="sub5">표의 항목을 클릭하여 상세보기</Heading>
       <Divider/>
       <ParticipantSessionTableFetcher />
     </>

--- a/packages/front-end/app/(sidebar-pages)/settings/_components/UserProfileEdit.tsx
+++ b/packages/front-end/app/(sidebar-pages)/settings/_components/UserProfileEdit.tsx
@@ -1,5 +1,4 @@
 import Button from "@/components/Button";
-import { Paragraph } from "@/components/Text";
 import { css } from "@/styled-system/css";
 import Image from "next/image";
 import { useRef, useState } from "react";
@@ -7,6 +6,7 @@ import LineEdit from "@/components/LineEdit";
 import { User } from "@/schema/backend.schema";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiClient } from "@/utils/axios";
+import { Label } from "@/components/Label";
 
 interface PropType {
   data: User;
@@ -42,13 +42,13 @@ export default function UserProfileEdit({ data }: PropType) {
     }
   };
 
-
   return (
     <form
       className={css({
         display: "flex",
         flexDirection: "column",
-        gap: "1em",
+        gap: "1rem",
+        width: "800px",
       })}
       ref={formRef}
       onSubmit={(e) => {
@@ -66,20 +66,21 @@ export default function UserProfileEdit({ data }: PropType) {
           gap: "1em",
         })}
       >
-        <Paragraph>프로필 사진</Paragraph>
+        <Label htmlFor="profileImage">프로필 사진</Label>
         <div className={css({ display: "flex", gap: "1.5rem" })}>
           <Image
             src={imageSrc}
             alt="프로필 사진"
             width={50}
             height={50}
-            className={css({ borderRadius: "50%",height:"50px" })}
+            className={css({ borderRadius: "50%", height: "50px" })}
           />
           <input
             type="file"
             accept="image/*"
             ref={fileInputRef}
             name="profileImage"
+            id="profileImage"
             onChange={handleImageChange}
             hidden
           />
@@ -89,20 +90,27 @@ export default function UserProfileEdit({ data }: PropType) {
                 fileInputRef.current.click();
               }
             }}
+            className={css({
+              backgroundColor: "green.600",
+              width: "200px",
+              height: "50px",
+            })}
           >
             수정하기
           </Button>
         </div>
-        <div>
-          <Paragraph>닉네임</Paragraph>
-          <LineEdit
-            placeholder="닉네임을 입력해 주세요."
-            defaultValue={data.nickname}
-            name="nickname"
-          />
-        </div>
+        <Label htmlFor="nickname">닉네임</Label>
+        <LineEdit
+          placeholder="닉네임을 입력해 주세요."
+          defaultValue={data.nickname}
+          name="nickname"
+          id="nickname"
+          className={css({ height: "50px" })}
+        />
       </div>
-      <Button type="submit">저장하기</Button>
+      <Button type="submit" className={css({ height: "50px" })}>
+        저장하기
+      </Button>
     </form>
   );
 }

--- a/packages/front-end/app/(sidebar-pages)/settings/page.tsx
+++ b/packages/front-end/app/(sidebar-pages)/settings/page.tsx
@@ -4,13 +4,28 @@ import { ErrorBoundary } from "react-error-boundary";
 import Divider from "@/components/Divider";
 import { Heading } from "@/components/Text";
 import UserProfileSettings from "./_components/UserProfileSettings";
+import { css } from "@/styled-system/css";
 
 export default function Page() {
   return (
-    <div>
+    <div
+      className={css({
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+      })}
+    >
       <Heading>설정</Heading>
+      <Heading variant="sub5">내 정보와 기본 닉네임을 수정</Heading>
       <Divider />
-      <div>
+      <div
+        className={css({
+          flexGrow: 1,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        })}
+      >
         <ErrorBoundary
           fallback={<h1>예기치 못한 오류가 발생하였습니다. [임시 컴포넌트]</h1>}
         >

--- a/packages/front-end/components/Label.tsx
+++ b/packages/front-end/components/Label.tsx
@@ -1,0 +1,9 @@
+import { styled } from "@/styled-system/jsx";
+
+export const Label = styled("label", {
+    base: {
+      fontWeight: "bold",
+      margin: "0.3rem 0",
+      fontSize: "1.25rem",
+    },
+  });

--- a/packages/front-end/components/Text.tsx
+++ b/packages/front-end/components/Text.tsx
@@ -1,7 +1,6 @@
 import { Styles } from "@/styled-system/css";
 import { styled } from "@/styled-system/jsx";
 
-
 const subStyle: Styles = {
   opacity: 0.65,
 };
@@ -45,8 +44,8 @@ export const Paragraph = styled("p", {
 });
 
 export const Heading = styled("h1", {
-  base:{
-    fontWeight:700,
+  base: {
+    fontWeight: 700,
   },
   variants: {
     variant: {
@@ -68,9 +67,33 @@ export const Heading = styled("h1", {
       h6: {
         fontSize: "1.25rem",
       },
+      sub1: {
+        fontSize: "2.5rem",
+        ...subStyle,
+      },
+      sub2: {
+        fontSize: "2rem",
+        ...subStyle,
+      },
+      sub3: {
+        fontSize: "1.75rem",
+        ...subStyle,
+      },
+      sub4: {
+        fontSize: "1.5rem",
+        ...subStyle,
+      },
+      sub5: {
+        fontSize: "1.25rem",
+        ...subStyle,
+      },
+      sub6: {
+        fontSize: "1rem",
+        ...subStyle,
+      },
     },
   },
-  defaultVariants:{
-    variant:"h3",
-  }
+  defaultVariants: {
+    variant: "h3",
+  },
 });


### PR DESCRIPTION
사이드바, 폼, 세션상세

## 📍 PR 타입 (하나 이상 선택)
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 [#]
close #320 
## 📄 개요
- 중간 평가 시연을 위해 일부 레이아웃을 변경
  - 사이드바
  - 폼(세션 정보변경 or 생성 & 유저 정보 변경)
  - secondary button 색 임시 변경
  - 부제목 생성 


## 🔁 변경 사항
**사진 참고(코드 및 피쳐 보단 시작적인 문제에 기반)**
### 사이드바 및 부제목 레이아웃
## 📸 동작 화면 스크린샷
![image](https://github.com/user-attachments/assets/00a0121b-aca7-403d-99b3-556927b5d9a3)
- 유튜브 로고 삭제
- 세션 참여 버튼 삭제(사이드바에 이미 존재)
- 유저 프로필 이미지 1:1 비율 보장
![image](https://github.com/user-attachments/assets/ab061606-f41e-4c4b-9fa4-067704ddbf7e)
- 폼 중앙 정렬 및 너비 제한
- 초록색 secondary 버튼으로 구분
- 라벨 font Weight 변경
- 유저 정보 수정 및 폼 정보 변경도 동일
- 참가자 입장 세션 상세보기는 버튼과 input 삭제
![image](https://github.com/user-attachments/assets/8b99572f-a1ef-42b8-ba66-65a43303e80d)
- 동일, ->(깨짐)가 아닌 글자로 변경

## 👀 기타 논의 사항
**추후 코드 리팩토링이 강제돼야함!!!!**