### PR TITLE
chore: socket-server build test work flow

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -30,9 +30,6 @@ jobs:
         env:
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
           YARN_ENABLE_HARDENED_MODE: 0
-      
-      - name: Gen panda-css styles
-        run: yarn front-end run prepare
 
       - name: Build front-end
         run: yarn front-end run build
@@ -64,3 +61,31 @@ jobs:
 
       - name: Build api-server
         run: yarn api-server run build
+
+  build-socket-server:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: "20"
+          cache: 'yarn'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Set Yarn version
+        run: corepack prepare yarn@4.3.1 --activate
+
+      - name: Install dependencies
+        run: yarn install
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: false
+          YARN_ENABLE_HARDENED_MODE: 0
+
+      - name: Build socket-server
+        run: yarn socket-server run build

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -24,6 +24,16 @@ jobs:
 
       - name: Set Yarn version
         run: corepack prepare yarn@4.3.1 --activate
+      
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.npm
+            ${{ github.workspace }}/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
 
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -3,7 +3,7 @@ name: Build-test
 on:
   pull_request:
     branches: [dev]
-    types: ["opened"]
+    types: ["opened", "synchronize"]
 
 jobs:
   build-front-end:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -3,7 +3,7 @@ name: Build-test
 on:
   pull_request:
     branches: [dev]
-    types: ['opened']
+    types: ["opened"]
 
 jobs:
   build-front-end:
@@ -17,28 +17,27 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: "20"
-          cache: 'yarn'
+          cache: "yarn"
 
       - name: Enable Corepack
         run: corepack enable
 
       - name: Set Yarn version
         run: corepack prepare yarn@4.3.1 --activate
-      
+
       - name: Cache dependencies
         uses: actions/cache@v4
         with:
           path: |
             ~/.npm
-            ${{ github.workspace }}/.next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
+            ${{ github.workspace }}/packages/front-end//.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('packages/front-end/**/*.js', '**/*.jsx', 'packages/front-end/**/*.ts', 'packages/front-end/**/*.tsx') }}
           restore-keys: |
             ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
 
       - name: Install dependencies
         run: yarn install
         env:
-          YARN_ENABLE_IMMUTABLE_INSTALLS: false
           YARN_ENABLE_HARDENED_MODE: 0
 
       - name: Build front-end
@@ -55,7 +54,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: "20"
-          cache: 'yarn'
+          cache: "yarn"
 
       - name: Enable Corepack
         run: corepack enable
@@ -83,7 +82,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: "20"
-          cache: 'yarn'
+          cache: "yarn"
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build-front-end:
+    if: contains(github.event.pull_request.changed_files, 'packages/front-end/')
     runs-on: ubuntu-latest
 
     steps:
@@ -44,6 +45,7 @@ jobs:
         run: yarn front-end run build
 
   build-api-server:
+    if: contains(github.event.pull_request.changed_files, 'packages/api-server/')
     runs-on: ubuntu-latest
 
     steps:
@@ -72,6 +74,8 @@ jobs:
         run: yarn api-server run build
 
   build-socket-server:
+    if: contains(github.event.pull_request.changed_files, 'packages/socket-server/')
+
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           path: |
             ~/.npm
-            ${{ github.workspace }}/packages/front-end//.next/cache
+            ${{ github.workspace }}/packages/front-end/.next/cache
           key: ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('packages/front-end/**/*.js', '**/*.jsx', 'packages/front-end/**/*.ts', 'packages/front-end/**/*.tsx') }}
           restore-keys: |
             ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-


### PR DESCRIPTION
소켓서버 빋르테스트

## 📍 PR 타입 (하나 이상 선택)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## ❗️ 관련 이슈 [#]
close #323 
## 📄 개요
- 소켓 서버가 개발됨에 따라 빌드 테스트 워크플로우 작성

## 🔁 변경 사항
- 같은 프레임워크를 사용해 api-server와 동일한 워크플로우입니다
- 첫 PR이후 커밋을 날려도 작동되도록 했습니다
```
types: ["opened", "synchronize"]
```
- nextjs cache를 사용합니다(워닝이 발생), 단 이것은 어떻게 사용하는지 확실치않아 리뷰좀ㅋㅋ
```
- name: Cache dependencies
        uses: actions/cache@v4
        with:
          path: |
            ~/.npm
            ${{ github.workspace }}/packages/front-end//.next/cache
          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('packages/front-end/**/*.js', '**/*.jsx', 'packages/front-end/**/*.ts', 'packages/front-end/**/*.tsx') }}
          restore-keys: |
            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
```
- 프로젝트에 필요한 job만 수행
  - 예를들어 소켓서버 파일 바뀌면 소켓서버만 빌드 테스트
## 📸 동작 화면 스크린샷

## 👀 기타 논의 사항
내가 나온 주의는 https://nextjs.org/docs/messages/no-cache 해당 링크에서 확인
```bash
⚠ No build cache found. Please configure build caching for faster rebuilds. Read more: https://nextjs.org/docs/messages/no-cache
# 이 밑은 nextjs가 정보수집해간다는 것, 무시하면 됨
Attention: Next.js now collects completely anonymous telemetry regarding usage.
This information is used to shape Next.js' roadmap and prioritize features.
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
```
해결법은 
```
uses: actions/cache@v4
with:
  # See here for caching with `yarn` https://github.com/actions/cache/blob/main/examples.md#node---yarn or you can leverage caching with actions/setup-node https://github.com/actions/setup-node
  path: |
    ~/.npm
    ${{ github.workspace }}/.next/cache
  # Generate a new cache whenever packages or source files change.
  key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
  # If source files changed but packages didn't, rebuild from a prior cache.
  restore-keys: |
    ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-

```
이런 형식으로 제공하나, 우리프로젝트에 맞게 yarn 및 모노레포 디렉토리 맞게 수정