### PR TITLE
chore: remove if condition

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   build-front-end:
-    if: contains(github.event.pull_request.changed_files, 'packages/front-end/')
     runs-on: ubuntu-latest
 
     steps:
@@ -45,7 +44,6 @@ jobs:
         run: yarn front-end run build
 
   build-api-server:
-    if: contains(github.event.pull_request.changed_files, 'packages/api-server/')
     runs-on: ubuntu-latest
 
     steps:
@@ -67,14 +65,12 @@ jobs:
       - name: Install dependencies
         run: yarn install
         env:
-          YARN_ENABLE_IMMUTABLE_INSTALLS: false
           YARN_ENABLE_HARDENED_MODE: 0
 
       - name: Build api-server
         run: yarn api-server run build
 
   build-socket-server:
-    if: contains(github.event.pull_request.changed_files, 'packages/socket-server/')
     runs-on: ubuntu-latest
 
     steps:
@@ -96,7 +92,6 @@ jobs:
       - name: Install dependencies
         run: yarn install
         env:
-          YARN_ENABLE_IMMUTABLE_INSTALLS: false
           YARN_ENABLE_HARDENED_MODE: 0
 
       - name: Build socket-server


### PR DESCRIPTION
프로젝트마다 동작을 제어하는 조건 제거

## 📍 PR 타입 (하나 이상 선택)
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## ❗️ 관련 이슈 [#]
close #329 
## 📄 개요
- 항상 skip되는 workflow

## 🔁 변경 사항
- if: contains(github.event.pull_request.changed_files, 'packages/project-name/') 를 삭제
  - 왜냐하면, 프로젝트 몇개 안돼서 조건별로 칠 필요 없음
  - 한 프로젝트가 빌드 타임을 크게 잡아먹어 지연시킬 가능성 적음
  - 팀원이 적으므로 예상치 못한 빌드 에러를 빠르게 커뮤니케이션 가능한 이점 존재

## 📸 동작 화면 스크린샷

## 👀 기타 논의 사항
- 그래서 왜 안되는걸까?