### PR TITLE
Be/332 socket userid and host

### DIFF
--- a/packages/socket-server/src/socket/socket.gateway.ts
+++ b/packages/socket-server/src/socket/socket.gateway.ts
@@ -49,7 +49,7 @@ export class SocketGateway
       console.log('invalid room for roomId:', this.roomUsers, client.rooms);
       return false;
     }
-    return true;
+    return userId;
   }
 
   async afterInit(server: Server) {
@@ -126,8 +126,8 @@ export class SocketGateway
     @ConnectedSocket() client: Socket,
     @MessageBody() { roomId, beforeIndex, currentIndex }: any,
   ): Promise<any> {
-    if (!(await this.isValidEvent(client, roomId))) return;
-    const userId: number = await this.socketService.validateUser(client);
+    const userId = await this.isValidEvent(client, roomId);
+    if (!userId) return;
     if (userId === this.roomHost[roomId]) {
       this.server.to(roomId).emit('getPageNumber', { currentIndex, userId });
     } else {
@@ -144,8 +144,8 @@ export class SocketGateway
     @ConnectedSocket() client: Socket,
     @MessageBody() { roomId, data, index }: any,
   ): Promise<any> {
-    if (!(await this.isValidEvent(client, roomId))) return;
-    const userId: number = await this.socketService.validateUser(client);
+    const userId = await this.isValidEvent(client, roomId);
+    if (!userId) return;
     if (userId !== this.roomHost[roomId]) return;
     this.server.to(roomId).emit('getAddedDraw', { data, index });
   }
@@ -155,8 +155,8 @@ export class SocketGateway
     @ConnectedSocket() client: Socket,
     @MessageBody() { roomId, data, index }: any,
   ): Promise<any> {
-    if (!(await this.isValidEvent(client, roomId))) return;
-    const userId: number = await this.socketService.validateUser(client);
+    const userId = await this.isValidEvent(client, roomId);
+    if (!userId) return;
     if (userId !== this.roomHost[roomId]) return;
     this.server.to(roomId).emit('getRemovedDraw', { data, index });
   }
@@ -166,8 +166,8 @@ export class SocketGateway
     @ConnectedSocket() client: Socket,
     @MessageBody() { roomId, data, index }: any,
   ): Promise<any> {
-    if (!(await this.isValidEvent(client, roomId))) return;
-    const userId: number = await this.socketService.validateUser(client);
+    const userId = await this.isValidEvent(client, roomId);
+    if (!userId) return;
     if (userId !== this.roomHost[roomId]) return;
     this.server.to(roomId).emit('getUpdatedDraw', { data, index });
   }

--- a/packages/socket-server/src/socket/socket.gateway.ts
+++ b/packages/socket-server/src/socket/socket.gateway.ts
@@ -119,9 +119,10 @@ export class SocketGateway
   @SubscribeMessage('sendPageNumber')
   async onSendPageNumber(
     @ConnectedSocket() client: any,
-    @MessageBody() { roomId, userId, index }: any,
+    @MessageBody() { roomId, index }: any,
   ): Promise<any> {
     if (!this.isValidEvent(client, roomId)) return;
+    const userId: number = await this.socketService.validateUser(client);
     // TODO: if Host: broadcast to participants, else: broadcast to the host
     this.server.to(roomId).emit('getPageNumber', { index, userId });
   }
@@ -132,6 +133,7 @@ export class SocketGateway
     @MessageBody() { roomId, data, index }: any,
   ): Promise<any> {
     if (!this.isValidEvent(client, roomId)) return;
+    const userId: number = await this.socketService.validateUser(client);
     this.server.to(roomId).emit('getAddedDraw', { data, index });
   }
 
@@ -141,6 +143,7 @@ export class SocketGateway
     @MessageBody() { roomId, data, index }: any,
   ): Promise<any> {
     if (!this.isValidEvent(client, roomId)) return;
+    const userId: number = await this.socketService.validateUser(client);
     this.server.to(roomId).emit('getRemovedDraw', { data, index });
   }
 
@@ -150,6 +153,7 @@ export class SocketGateway
     @MessageBody() { roomId, data, index }: any,
   ): Promise<any> {
     if (!this.isValidEvent(client, roomId)) return;
+    const userId: number = await this.socketService.validateUser(client);
     this.server.to(roomId).emit('getUpdatedDraw', { data, index });
   }
 }

--- a/packages/socket-server/src/socket/socket.gateway.ts
+++ b/packages/socket-server/src/socket/socket.gateway.ts
@@ -37,6 +37,7 @@ export class SocketGateway
   roomHost: { [key: string]: number } = {};
   roomHostSocket: { [key: string]: Socket } = {};
   clientUserId: { [key: string]: number } = {};
+  roomPageViewerCount: { [key: string]: number[] } = {};
 
   private async isValidEvent(client: any, roomId: any) {
     const userId: number = await this.socketService.validateUser(client);
@@ -125,7 +126,11 @@ export class SocketGateway
   ): Promise<any> {
     if (!(await this.isValidEvent(client, roomId))) return;
     const userId: number = await this.socketService.validateUser(client);
-    this.server.to(roomId).emit('getPageNumber', { index, userId });
+    if (userId === this.roomHost[roomId]) {
+      this.server.to(roomId).emit('getPageNumber', { index, userId });
+    } else {
+      this.roomHostSocket[roomId].emit('getPageNumber', {});
+    }
   }
 
   @SubscribeMessage('sendAddedDraw')

--- a/packages/socket-server/src/socket/socket.service.ts
+++ b/packages/socket-server/src/socket/socket.service.ts
@@ -3,6 +3,7 @@ import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { JwtPayload } from '../auth/jwt.payload';
 import cookie from 'cookie';
+import { Socket } from 'socket.io';
 
 @Injectable()
 export class SocketService {
@@ -11,7 +12,7 @@ export class SocketService {
     private configService: ConfigService,
   ) {}
 
-  async validateUser(socket: any): Promise<number> {
+  async validateUser(socket: Socket): Promise<number> {
     try {
       const cookies = socket.request.headers.cookie;
       if (!cookies) return 0;


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가

## ❗️ 관련 이슈 [#]
#322 

## 📄 개요
- userId를 통해 이벤트를 보낸 사람이 host인지 파악
- host socket 자체를 저장함
- roomPageViewerCount를 두어 host socket에만 참가자들이 보는 페이지를 보내게 함

## 🔁 변경 사항
### 변경 내용을 적어주세요 (커밋 번호를 적어주세요)
```
async onSendPageNumber(
    @ConnectedSocket() client: Socket,
    @MessageBody() { roomId, beforeIndex, currentIndex }: any,
  ): Promise<any> {
   ...
    this.roomPageViewerCount[roomId][beforeIndex] -= 1;
    this.roomPageViewerCount[roomId][currentIndex] += 1;
   ...
```
beforeIndex, currentIndex를 보내게 해 참가자가 보는 페이지를 갱신할 수 있게 함

## 📸 동작 화면 스크린샷

## 👀 기타 논의 사항