### PR TITLE
feat: useSetResize custom hook

### DIFF
--- a/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
@@ -57,7 +57,7 @@ export default function HostViewer({
           zIndex: 50,
         })}
       >
-        <Tldraw store={store} />
+        {/* <Tldraw store={store} /> */}
       </div>
     </div>
   ) : (

--- a/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
@@ -57,7 +57,7 @@ export default function HostViewer({
           zIndex: 50,
         })}
       >
-        {/* <Tldraw store={store} /> */}
+        <Tldraw store={store} />
       </div>
     </div>
   ) : (

--- a/packages/front-end/components/DocumentViewer/hooks/useSetSize.ts
+++ b/packages/front-end/components/DocumentViewer/hooks/useSetSize.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useResizeObserver } from "usehooks-ts";
+import { pdfjs } from "react-pdf";
+
+export const useSetSize = () => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [pageWidth, setPageWidth] = useState(0);
+  const [pageHeight, setPageHeight] = useState(0);
+  const [pageOriginalWidth, setPageOriginalWidth] = useState<null | number>(
+    null
+  );
+  const [pageOriginalHeight, setPageOriginalHeight] = useState<null | number>(
+    null
+  );
+
+  const handleResize = useCallback(
+    (size: { width: number | undefined; height: number | undefined }) => {
+      const { width, height } = size;
+      if (width === undefined || height === undefined) return;
+      if (pageOriginalHeight === null || pageOriginalWidth === null) return;
+      const aspectRatio = pageOriginalHeight / pageOriginalWidth;
+      const sizeRefFromWidth = { width: width, height: width * aspectRatio };
+      const sizeRefFromHeight = { width: height / aspectRatio, height: height };
+      if (sizeRefFromWidth.height > sizeRefFromHeight.height) {
+        setPageWidth(sizeRefFromHeight.width);
+        setPageHeight(sizeRefFromHeight.height);
+      } else {
+        setPageWidth(sizeRefFromWidth.width);
+        setPageHeight(sizeRefFromWidth.height);
+      }
+    },
+    [pageOriginalHeight, pageOriginalWidth]
+  );
+
+  const onPageLoadSuccess = (
+    page: {
+      width: number;
+      height: number;
+      originalWidth: number | null;
+      originalHeight: number | null;
+    } & pdfjs.PDFPageProxy
+  ) => {
+    setPageOriginalWidth(page.originalWidth);
+    setPageOriginalHeight(page.originalHeight);
+  };
+
+  useEffect(() => {
+    const handleResizeEvent = () => {
+      if (containerRef.current === null) return;
+      const size = containerRef.current.getBoundingClientRect();
+      handleResize(size);
+    };
+    handleResizeEvent();
+    window.addEventListener("resize", handleResizeEvent);
+    return () => window.removeEventListener("resize", handleResizeEvent);
+  }, [handleResize]);
+
+  return { containerRef, pageWidth, pageHeight, onPageLoadSuccess };
+};

--- a/packages/front-end/components/DocumentViewer/hooks/useSetSize.ts
+++ b/packages/front-end/components/DocumentViewer/hooks/useSetSize.ts
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useResizeObserver } from "usehooks-ts";
 import { pdfjs } from "react-pdf";
 
 export const useSetSize = () => {

--- a/packages/front-end/components/DocumentViewer/PDF/PDFViewer.tsx
+++ b/packages/front-end/components/DocumentViewer/PDF/PDFViewer.tsx
@@ -4,30 +4,29 @@ import { Document, Page } from "react-pdf";
 import { css } from "@/styled-system/css";
 import "react-pdf/dist/Page/TextLayer.css";
 import "react-pdf/dist/Page/AnnotationLayer.css";
-import { useResizeObserver } from 'usehooks-ts';
-
+import { useSetSize } from "../\bhooks/useSetSize";
 
 pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`;
 
-
-export default function PDFViewer({ documentURL, defaultPageIndex = 0 }: { documentURL: string, defaultPageIndex?: number }) {
-  const documentRef = useRef(null)
-  const { width = 0, height = 0 } = useResizeObserver({
-    ref: documentRef,
-    box: "border-box",
-  });
+export default function PDFViewer({
+  documentURL,
+  defaultPageIndex = 0,
+}: {
+  documentURL: string;
+  defaultPageIndex?: number;
+}) {
+  const { containerRef, pageWidth, pageHeight,onPageLoadSuccess } = useSetSize();
 
   const [pageCount, setPageCount] = useState<number | null>(null);
-  const [currentPageIndex, setCurrentPageIndex] = useState<number>(defaultPageIndex);
+  const [currentPageIndex, setCurrentPageIndex] =
+    useState<number>(defaultPageIndex);
 
   useEffect(() => {
-    if (pageCount === null)
-      return;
+    if (pageCount === null) return;
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "ArrowRight") {
         setCurrentPageIndex((index) => Math.min(pageCount - 1, index + 1));
-      }
-      else if (event.key === "ArrowLeft") {
+      } else if (event.key === "ArrowLeft") {
         setCurrentPageIndex((index) => Math.max(0, index - 1));
       }
     };
@@ -39,36 +38,48 @@ export default function PDFViewer({ documentURL, defaultPageIndex = 0 }: { docum
 
   const onDocumentLoadSuccess = (pdf: pdfjs.PDFDocumentProxy) => {
     setPageCount(pdf.numPages);
-    setCurrentPageIndex(Math.min(Math.max(0, currentPageIndex), pdf.numPages - 1));
-  }
+    setCurrentPageIndex(
+      Math.min(Math.max(0, currentPageIndex), pdf.numPages - 1)
+    );
+  };
 
   return (
     <div
-      ref={documentRef}
       className={css({
-        position: "relative",
         width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
       })}
     >
-      <Document
-        file={documentURL}
-        onLoadSuccess={onDocumentLoadSuccess}
+      <div
+        className={css({
+          display: "flex",
+          padding: "1em",
+          color: "#ffffff",
+          backgroundColor: "#000000",
+          justifyContent: "center",
+          alignItems: "center",
+        })}
       >
-        <Page width={width} pageIndex={currentPageIndex} />
-      </Document>
-      <div className={css({
-        position: "sticky",
-        bottom: "0",
-        left: "0",
-        display: "flex",
-        padding: "1em",
-        color: "#ffffff",
-        backgroundColor: "#000000",
-        justifyContent: "center",
-        alignItems: "center",
-        zIndex: 2,
-      })}>
         {currentPageIndex + 1} / {pageCount}
+      </div>
+      <div
+        ref={containerRef}
+        className={css({
+          position: "relative",
+          flexGrow: 1,
+          overflow:"hidden",
+        })}
+      >
+        <Document file={documentURL} onLoadSuccess={onDocumentLoadSuccess}>
+          <Page
+            pageIndex={currentPageIndex}
+            onLoadSuccess={onPageLoadSuccess}
+            width={pageWidth}
+            height={pageHeight}
+          />
+        </Document>
       </div>
     </div>
   );


### PR DESCRIPTION
리사이즈 이벤트핸들러를 이용해 적절한 pdf크기 불러옴

## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정


## ❗️ 관련 이슈 [#]
close #331 
## 📄 개요
- 현재 가로로 긴 디바이스에 대해 pdf크기가 밖으로 삐져나옴
- 따라서 다른 sub UI를 고려해 남는 공간에 PDF를 원본비율로 꽉 채우는 로직을 구현

## 🔁 변경 사항
### 변수 및 상태
```typescript
  const containerRef = useRef<HTMLDivElement>(null); // 크기 기준점이 될 element ref
  const [pageWidth, setPageWidth] = useState(0); // pdf Page의 크기
  const [pageHeight, setPageHeight] = useState(0);
  const [pageOriginalWidth, setPageOriginalWidth] = useState<null | number>(
    null
  ); // pdf 원본 문서의 크기
  const [pageOriginalHeight, setPageOriginalHeight] = useState<null | number>(
    null
  ); 
```
### Resize 핸들러(페이지 사이즈 설정 핸들러)
```typescript
  const handleResize = useCallback(
    (size: { width: number | undefined; height: number | undefined }) => {
      const { width, height } = size;
      if (width === undefined || height === undefined) return; // 크기가 정의 안된 경우 
      if (pageOriginalHeight === null || pageOriginalWidth === null) return; // pdf가 아직 로드 안된 경우
      const aspectRatio = pageOriginalHeight / pageOriginalWidth; // 원본 파일 비율 계산
      const sizeRefFromWidth = { width: width, height: width * aspectRatio }; // 너비기준 Rect
      const sizeRefFromHeight = { width: height / aspectRatio, height: height }; // 너비기준 Rect
      if (sizeRefFromWidth.height > sizeRefFromHeight.height) { // 만약 너비 기준으로 꽉 채운 높이가 높이 기준으로 꽉 채운 높이보다 크다면
      // 높이 기준으로 Rect설정
        setPageWidth(sizeRefFromHeight.width);
        setPageHeight(sizeRefFromHeight.height);
      } else {
      // 너비 기준으로 Rect설정
        setPageWidth(sizeRefFromWidth.width);
        setPageHeight(sizeRefFromWidth.height);
      }
    },
    [pageOriginalHeight, pageOriginalWidth]
  );
```
### 원본 pdf 문서 크기 설정
```typescript
  const onPageLoadSuccess = (
    page: {
      width: number;
      height: number;
      originalWidth: number | null;
      originalHeight: number | null; 
    } & pdfjs.PDFPageProxy // PDFPageProxy에 적절한 properties가 존재안함 콘솔에 찍어보면 나오는데?
  ) => {
    setPageOriginalWidth(page.originalWidth);
    setPageOriginalHeight(page.originalHeight);
  };
```
### resize 이벤트 핸들러
```typescript
  useEffect(() => {
    const handleResizeEvent = () => {
      if (containerRef.current === null) return;
      const size = containerRef.current.getBoundingClientRect();
      handleResize(size);
    }; // addEventListener에 적절한 함수 주입, custom param이 있으므로 선언
    handleResizeEvent(); // 화면 로드시 강제 실행
    window.addEventListener("resize", handleResizeEvent); // 화면 크기가 바뀌는 경우(정확히는 element 크기)
    return () => window.removeEventListener("resize", handleResizeEvent);
  }, [handleResize]);
// 참고) 디바운스나 쓰로틀링이 요구될수도 있음
```
### 적용
```typescript
      <div
        ref={containerRef} // 컨테이너
        className={css({
          position: "relative",
          flexGrow: 1,
          overflow:"hidden",
        })}
      >
        <Document file={documentURL} onLoadSuccess={onDocumentLoadSuccess}>
          <Page
            pageIndex={currentPageIndex}
            onLoadSuccess={onPageLoadSuccess} // 원본pdf페이지 크기 구하기
            width={pageWidth}
            height={pageHeight}
          />
        </Document>
      </div>
```
## 📸 동작 화면 스크린샷
![image](https://github.com/user-attachments/assets/805ca03a-5f50-4238-8ca2-4427b02d185e)
![image](https://github.com/user-attachments/assets/d9216e0c-5b93-4aa9-9fca-69af4c5451be)
* 다양한 크기의 pdf를 로드하는 모습
## 👀 기타 논의 사항
- resizeObserver API 유틸인 usehooks-ts/useResizeObserver에 경우 초기 로드시 화면 크기를 삐져나오게 로드함(리사이즈 로직이 동작 안함)
  - 리랜더링을 줄인 API이므로 useResizeObserver에서 로드시 강제적으로 onResize를 동작하는 방법이 궁금, 처리 시간이 최적화 될 것임
- 당연히, tldraw 캔버스는 뷰포트를 현재 꽉 채움
  - 추후 적절한 zoom설정로직이 구현되면 구성을 바꾸는게 좋아보임