### PR TITLE
fix: don't render East Asian text in legacy pdf file

### DIFF
--- a/packages/front-end/components/DocumentViewer/PDF/PDFViewer.tsx
+++ b/packages/front-end/components/DocumentViewer/PDF/PDFViewer.tsx
@@ -8,14 +8,29 @@ import { useSetSize } from "../\bhooks/useSetSize";
 
 pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`;
 
+/**
+* Warning: 레거시 PDF에만 적용돠는 옵션
+* PDF 1.3이전 한글 문서에 필요하지만 어떤 문제가 발생할지 모름
+* 
+* [참고 링크 1: stack overflow](https://stackoverflow.com/questions/32764773/what-is-a-pdf-bcmap-file)
+* 
+* [참고 링크 2: 관련 github 이슈](https://github.com/huridocs/uwazi/issues/3723)
+*/
+const cmapOption = {
+  cMapUrl: `//unpkg.com/pdfjs-dist@${pdfjs.version}/cmaps/`,
+  cMapPacked: true,
+};
+
 export default function PDFViewer({
   documentURL,
   defaultPageIndex = 0,
+
 }: {
   documentURL: string;
   defaultPageIndex?: number;
 }) {
-  const { containerRef, pageWidth, pageHeight,onPageLoadSuccess } = useSetSize();
+  const { containerRef, pageWidth, pageHeight, onPageLoadSuccess } =
+    useSetSize();
 
   const [pageCount, setPageCount] = useState<number | null>(null);
   const [currentPageIndex, setCurrentPageIndex] =
@@ -69,10 +84,14 @@ export default function PDFViewer({
         className={css({
           position: "relative",
           flexGrow: 1,
-          overflow:"hidden",
+          overflow: "hidden",
         })}
       >
-        <Document file={documentURL} onLoadSuccess={onDocumentLoadSuccess}>
+        <Document
+          file={documentURL}
+          onLoadSuccess={onDocumentLoadSuccess}
+          options={cmapOption}
+        >
           <Page
             pageIndex={currentPageIndex}
             onLoadSuccess={onPageLoadSuccess}

--- a/packages/front-end/components/DocumentViewer/PDF/PDFViewer.tsx
+++ b/packages/front-end/components/DocumentViewer/PDF/PDFViewer.tsx
@@ -90,7 +90,7 @@ export default function PDFViewer({
         <Document
           file={documentURL}
           onLoadSuccess={onDocumentLoadSuccess}
-          options={cmapOption}
+          options={cmapOption} // JSDocs
         >
           <Page
             pageIndex={currentPageIndex}


### PR DESCRIPTION
pdf 1.3버전으로 생성된 pdf에서 한국어가 안됨

## 📍 PR 타입 (하나 이상 선택)
- [ ] 버그 수정

## ❗️ 관련 이슈 [#]
close #349
## 📄 개요
- PDF 1.3이하 버전으로 만들어진 파일이 pdfjs로 한글 로드가 안되는 문제

## 🔁 변경 사항
- 해당 로직 적용시 아직 무슨 문제가 있는 건지 몰라 JSDocs로 관련 링크 및 메시지를 적용 
- CJK(동아시아 언어) 문자를 로드할때 필요한 cmap파일이 없어 발생

## 📸 동작 화면 스크린샷

## 👀 기타 논의 사항
- [이 방법이 왜 문제가 되는지](https://stackoverflow.com/questions/32764773/what-is-a-pdf-bcmap-file)알면 답변 바람