### PR TITLE
Be/360 session code fix

### DIFF
--- a/packages/api-server/src/sessions/sessions.service.ts
+++ b/packages/api-server/src/sessions/sessions.service.ts
@@ -78,7 +78,8 @@ export class SessionsService {
   async makeSessionCode(sessionId: number) {
     const session: Session = await this.findOne(sessionId);
     const code: string = bcrypt.hashSync(session.sessionName + Date.now(), 10);
-    return code.slice(0, 6);
+    console.log(code);
+    return code.slice(7, 13);
   }
 
   async getSessionByCode(sessionCode: string): Promise<SessionResponseDto> {

--- a/packages/api-server/src/sessions/sessions.service.ts
+++ b/packages/api-server/src/sessions/sessions.service.ts
@@ -99,7 +99,6 @@ export class SessionsService {
   async makeSessionCode(sessionId: number) {
     const session: Session = await this.findOne(sessionId);
     const code: string = bcrypt.hashSync(session.sessionName + Date.now(), 10);
-    console.log(code);
     return code.slice(7, 13);
   }
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정

## ❗️ 관련 이슈 [#]
#360 

## 📄 개요
- session code를 만들 때 bcrypt로 인코딩 함
  - bcrypt로 하면 앞에 $2b$10$ 이런 헤더가 붙음
  - 헤더 뒤에서 자르는 걸로 수정
- 세션 상태 수정
  - 세션 상태가 open일 때 open요청 오거나 close일 때 close 요청 오면 bad request
  - 세션이 없거나 내것이 아닐 경우 not found로 가게 했음

## 🔁 변경 사항
### 변경 내용을 적어주세요 (커밋 번호를 적어주세요)
```
async makeSessionCode(sessionId: number) {
    const session: Session = await this.findOne(sessionId);
    const code: string = bcrypt.hashSync(session.sessionName + Date.now(), 10);
    return code.slice(7, 13);
  }
```
-> 여긴 `bcrypt`로 해싱하면 `$2b$10$`이 붙어서 나와서 7부터 잘라야함

```
async changeSessionStatus(
    userId: number,
    sessionId: number,
    status: string,
  ): Promise<SessionStatusResponseDto> {
    // 내가 연 세션이 있는지 확인
    const session: Session = await this.sessionRepository.findOneBy({
      hostId: userId,
      sessionId,
    }); 
    // 세션 Id에 해당하는 세션이 없거나 내가 연 세션이 아니라면 exception
    if (!session)
      throw new NotFoundException(
        `Session with ID: ${sessionId} does not exist or you do not have permission to control it.`,
      );

    if (status === 'open') {
      if (session.sessionCode !== '') // 세션 코드가 이미 존재한다면 세션 open 요청이 이미 처리된거임
        throw new BadRequestException( // 그래서 exception
          `Session with ID: ${sessionId} is already opened.`,
        );
      const sessionCode: string = await this.makeSessionCode(sessionId);
      await this.sessionRepository.update(sessionId, { sessionCode });
      return { sessionCode };
    } else {
      if (session.sessionCode === '') // 세션 코드가 없다면 세션 close 요청이 이미 처리된거임
        throw new BadRequestException( // 그래서 exception
          `Session with ID: ${sessionId} is already closed.`,
        );
      await this.sessionRepository.update(sessionId, { sessionCode: '' });
      return { sessionCode: '' };
    }
  }
```

## 📸 동작 화면 스크린샷

## 👀 기타 논의 사항