### PR TITLE
feat: return useEffect until setInterval

### DIFF
--- a/packages/front-end/app/view/[sessionId]/_hooks/useBatchSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useBatchSocket.ts
@@ -8,7 +8,7 @@ type ElementType = {
   data: TLRecord | [TLRecord, TLRecord];
 };
 
-const INTERVAL_TIME = 50; // fps = 1000 / INTERVAL_TIME
+const INTERVAL_TIME = 100; // fps = 1000 / INTERVAL_TIME
 /**
  *    ## 가정
  *    - added -> updated -> removed는 순서가 보장
@@ -144,8 +144,8 @@ export const useBatchSocket = ({
 
   // process data & send at intervals
   useEffect(() => {
+    if (socket === null) return;
     const intervalId = setInterval(() => {
-      if (socket === null) return;
       const dataFormat = processBatchQueue();
       const messageBody = {
         index: 1,


### PR DESCRIPTION
소켓이 비어있음 유즈이펙트를 종료한다. 인터벌발생을 막음

## 📍 PR 타입 (하나 이상 선택)
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 [#]
없음
## 📄 개요
- 로컬에 바뀐거 있길래 diff봐서 커밋 새로 날렸습니다...

## 🔁 변경 사항
- 코드보면 암!
- 소켓인스탄스가 널이면 그냥 setInterval작업안하게함

## 📸 동작 화면 스크린샷

## 👀 기타 논의 사항