### PR TITLE
378 connect socket

### DIFF
--- a/packages/front-end/PaintPDF/components/PDFPainter/hooks/usePDFPainterInstanceController.ts
+++ b/packages/front-end/PaintPDF/components/PDFPainter/hooks/usePDFPainterInstanceController.ts
@@ -1,88 +1,102 @@
 import { useMemo, useCallback } from "react";
 
 import {
-	EditorSnapshot,
-	PainterShape,
-	PainterShapeId,
-	PDFPainterController,
-	PDFPainterInstanceController,
-	PDFPainterInstanceControllerHook,
-	PDFPainterInstanceStoreUpdateHandler,
+  EditorSnapshot,
+  PainterShape,
+  PainterShapeId,
+  PDFPainterController,
+  PDFPainterInstanceController,
+  PDFPainterInstanceControllerHook,
+  PDFPainterInstanceStoreUpdateHandler,
 } from "../types";
 import { Editor } from "tldraw";
 
 export const usePDFPainterInstanceController = ({
-	editorId,
-	pdfPainterController,
-	onStoreUpdate = () => {},
+  editorId,
+  pdfPainterController,
+  onStoreUpdate = () => {},
 }: {
-	editorId: string;
-	pdfPainterController: PDFPainterController;
-	onStoreUpdate?: PDFPainterInstanceStoreUpdateHandler;
+  editorId: string;
+  pdfPainterController: PDFPainterController;
+  onStoreUpdate?: PDFPainterInstanceStoreUpdateHandler;
 }): PDFPainterInstanceControllerHook => {
-	const onEditorLoad = useCallback(
-		(editor: Editor) => {
-			pdfPainterController.registerEditor(editorId, editor);
-			editor.store.listen(({ changes }) => onStoreUpdate(changes), { source: "user", scope: "document" });
-		},
-		[editorId, pdfPainterController, onStoreUpdate],
-	);
+  const onEditorLoad = useCallback(
+    (editor: Editor) => {
+      pdfPainterController.registerEditor(editorId, editor);
+      editor.store.listen(({ changes }) => onStoreUpdate(changes), {
+        source: "user",
+        scope: "document",
+      });
+    },
+    [editorId, pdfPainterController, onStoreUpdate]
+  );
 
-	const pdfPainterInstanceController: PDFPainterInstanceController = useMemo(() => {
-		return {
-			getEditor: () => pdfPainterController.getEditor(editorId),
-			getEditorSnapshot: (pageIndex: number) => pdfPainterController.getEditorSnapshot(editorId, pageIndex),
-			setEditorSnapshot: (pageIndex: number, snapshot: EditorSnapshot) => pdfPainterController.setEditorSnapshot(editorId, pageIndex, snapshot),
-			clearEditorSnapshot: (pageIndex: number) => pdfPainterController.clearEditorSnapshot(editorId, pageIndex),
-			getPaintElement: (elementId: PainterShapeId) => {
-				const editor = pdfPainterController.getEditor(editorId);
-				if (editor === null) {
-					return null;
-				}
-				if (editor.store.has(elementId)) {
-					return editor.store.get(elementId) as PainterShape;
-				}
-				return null;
-			},
-			addPaintElement: (elementData: PainterShape) => {
-				const editor = pdfPainterController.getEditor(editorId);
-				if (editor === null) {
-					return;
-				}
-				editor.store.put([elementData]);
-			},
-			updatePaintElement: (elementId: PainterShapeId, elementData: PainterShape) => {
-				const editor = pdfPainterController.getEditor(editorId);
-				if (editor === null) {
-					return;
-				}
-				if (editor.store.has(elementId)) {
-					editor.store.update(elementId, () => elementData);
-				}
-			},
-			removePaintElement: (elementId: PainterShapeId) => {
-				const editor = pdfPainterController.getEditor(editorId);
-				if (editor === null) {
-					return;
-				}
-				if (editor.store.has(elementId)) {
-					editor.store.remove([elementId]);
-				}
-			},
-			updatePaintElementByGenerator: (elementId: PainterShapeId, elementGenerator: (previousElementData: PainterShape) => PainterShape) => {
-				const editor = pdfPainterController.getEditor(editorId);
-				if (editor === null) {
-					return;
-				}
-				if (editor.store.has(elementId)) {
-					editor.store.update(elementId, elementGenerator);
-				}
-			},
-		};
-	}, [editorId, pdfPainterController]);
+  const pdfPainterInstanceController: PDFPainterInstanceController =
+    useMemo(() => {
+      return {
+        getEditor: () => pdfPainterController.getEditor(editorId),
+        getEditorSnapshot: (pageIndex: number) =>
+          pdfPainterController.getEditorSnapshot(editorId, pageIndex),
+        setEditorSnapshot: (pageIndex: number, snapshot: EditorSnapshot) =>
+          pdfPainterController.setEditorSnapshot(editorId, pageIndex, snapshot),
+        clearEditorSnapshot: (pageIndex: number) =>
+          pdfPainterController.clearEditorSnapshot(editorId, pageIndex),
+        getPaintElement: (elementId: PainterShapeId) => {
+          const editor = pdfPainterController.getEditor(editorId);
+          if (editor === null) {
+            return null;
+          }
+          if (editor.store.has(elementId)) {
+            return editor.store.get(elementId) as PainterShape;
+          }
+          return null;
+        },
+        addPaintElement: (elementData: PainterShape[]) => {
+          const editor = pdfPainterController.getEditor(editorId);
+          if (editor === null) {
+            return;
+          }
+          editor.store.put(elementData);
+        },
+        updatePaintElement: (
+          elementId: PainterShapeId,
+          elementData: PainterShape
+        ) => {
+          const editor = pdfPainterController.getEditor(editorId);
+          if (editor === null) {
+            return;
+          }
+          if (editor.store.has(elementId)) {
+            editor.store.update(elementId, () => elementData);
+          }
+        },
+        removePaintElement: (elementIds: PainterShapeId[]) => {
+          const editor = pdfPainterController.getEditor(editorId);
+          if (editor === null) {
+            return;
+          }
+          const validatedElementIds = elementIds.filter((e) =>
+            editor.store.has(e)
+          );
+          editor.store.remove(validatedElementIds);
+        },
+        updatePaintElementByGenerator: (
+          elementId: PainterShapeId,
+          elementGenerator: (previousElementData: PainterShape) => PainterShape
+        ) => {
+          const editor = pdfPainterController.getEditor(editorId);
+          if (editor === null) {
+            return;
+          }
+          if (editor.store.has(elementId)) {
+            editor.store.update(elementId, elementGenerator);
+          }
+        },
+      };
+    }, [editorId, pdfPainterController]);
 
-	return {
-		pdfPainterInstanceController: pdfPainterInstanceController,
-		onEditorLoad: onEditorLoad,
-	};
+  return {
+    pdfPainterInstanceController: pdfPainterInstanceController,
+    onEditorLoad: onEditorLoad,
+  };
 };

--- a/packages/front-end/PaintPDF/components/PDFPainter/types/index.ts
+++ b/packages/front-end/PaintPDF/components/PDFPainter/types/index.ts
@@ -38,9 +38,9 @@ export type PDFPainterInstanceController = {
 	setEditorSnapshot: (pageIndex: number, snapshot: EditorSnapshot) => void;
 	clearEditorSnapshot: (pageIndex: number) => void;
 	getPaintElement: (elementId: PainterShapeId) => PainterShape | null;
-	addPaintElement: (elementData: PainterShape) => void;
+	addPaintElement: (elementData: PainterShape[]) => void;
 	updatePaintElement: (elementId: PainterShapeId, elementData: PainterShape) => void;
-	removePaintElement: (elementId: PainterShapeId) => void;
+	removePaintElement: (elementIds: PainterShapeId[]) => void;
 	updatePaintElementByGenerator: (elementId: PainterShapeId, elementGenerator: (previousElementData: PainterShape) => PainterShape) => void;
 };
 

--- a/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
@@ -10,10 +10,10 @@ import {
 import { ViewerPropType } from "../_types/ViewerType";
 
 export default function HostViewer(props: ViewerPropType) {
-  const { sessionName, fileList, userId, sessionId } = props;
+  const { fileList, userId, sessionId } = props;
   const pdfDocument = fileList[0];
   const pdfPainterControllerHook = usePDFPainterController({
-    painterId: `${sessionName}_${pdfDocument.fileId}`,
+    painterId: `${sessionId}_${pdfDocument.fileId}`,
   });
   const pdfPainterHostInstanceControllerHook = usePDFPainterInstanceController({
     editorId: "Host",

--- a/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
@@ -5,7 +5,12 @@ import { AxiosResponse } from "axios";
 import { Session, File } from "@/schema/backend.schema";
 import { apiClient } from "@/utils/axios";
 import { useHostSocket } from "../_hooks/useHostSocket";
-import { PainterInstanceGenerator, PDFPainter } from "@/PaintPDF/components";
+import {
+  PainterInstanceGenerator,
+  PDFPainter,
+  usePDFPainterController,
+  usePDFPainterInstanceController,
+} from "@/PaintPDF/components";
 
 interface SessionReturnType extends Session {
   fileList: File[];
@@ -30,7 +35,18 @@ export default function HostViewer({
   });
   const data = response?.data;
 
-  const store = useHostSocket(params.userId, params.sessionId);
+  const pdfPainterControllerHook = usePDFPainterController({
+    painterId: "Session123_File123",
+  });
+  const pdfPainterHostInstanceControllerHook = usePDFPainterInstanceController({
+    editorId: "Host",
+    pdfPainterController: pdfPainterControllerHook.pdfPainterController,
+  });
+  const store = useHostSocket(
+    params.userId,
+    params.sessionId,
+    pdfPainterHostInstanceControllerHook
+  );
 
   if (isLoading) {
     return <p>로딩...</p>;
@@ -59,8 +75,15 @@ export default function HostViewer({
       <PDFPainter
         painterId={`${data.sessionId}_${pdfDocument.fileId}`}
         pdfDocumentURL={pdfDocument.url}
+        customPdfPainterControllerHook={pdfPainterControllerHook}
       >
-        <PainterInstanceGenerator instanceId={"Host"} readOnly={false} />
+        <PainterInstanceGenerator
+          instanceId={"Host"}
+          readOnly={false}
+          customPdfPainterInstanceControllerHook={
+            pdfPainterHostInstanceControllerHook
+          }
+        />
       </PDFPainter>
     </div>
   );

--- a/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
@@ -19,7 +19,12 @@ export default function HostViewer(props: ViewerPropType) {
     editorId: "Host",
     pdfPainterController: pdfPainterControllerHook.pdfPainterController,
   });
-  useHostSocket(userId, sessionId, pdfPainterHostInstanceControllerHook);
+  useHostSocket(
+    userId,
+    sessionId,
+    pdfPainterHostInstanceControllerHook,
+    pdfPainterControllerHook
+  );
 
   return (
     <div

--- a/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
@@ -20,7 +20,6 @@ export default function HostViewer(props: ViewerPropType) {
     pdfPainterController: pdfPainterControllerHook.pdfPainterController,
   });
   useHostSocket(
-    userId,
     sessionId,
     pdfPainterHostInstanceControllerHook,
     pdfPainterControllerHook

--- a/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
@@ -21,8 +21,8 @@ export default function HostViewer(props: ViewerPropType) {
   });
   useHostSocket(
     sessionId,
-    pdfPainterHostInstanceControllerHook,
-    pdfPainterControllerHook
+    pdfPainterHostInstanceControllerHook.pdfPainterInstanceController,
+    pdfPainterControllerHook.pdfPainterController
   );
 
   return (

--- a/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
@@ -40,8 +40,8 @@ export default function ParticipantViewer(props: ViewerPropType) {
     });
   useParticipantSocket(
     sessionId,
-    pdfPainterHostInstanceControllerHook,
-    pdfPainterControllerHook
+    pdfPainterHostInstanceControllerHook.pdfPainterInstanceController,
+    pdfPainterControllerHook.pdfPainterController
   );
 
   if (joinQuery.isLoading) {

--- a/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
@@ -38,7 +38,12 @@ export default function ParticipantViewer(props: ViewerPropType) {
       editorId: "Participant",
       pdfPainterController: pdfPainterControllerHook.pdfPainterController,
     });
-  useParticipantSocket(userId, sessionId, pdfPainterHostInstanceControllerHook);
+  useParticipantSocket(
+    userId,
+    sessionId,
+    pdfPainterHostInstanceControllerHook,
+    pdfPainterControllerHook
+  );
 
   if (joinQuery.isLoading) {
     return <p>로딩...</p>;

--- a/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
@@ -39,7 +39,6 @@ export default function ParticipantViewer(props: ViewerPropType) {
       pdfPainterController: pdfPainterControllerHook.pdfPainterController,
     });
   useParticipantSocket(
-    userId,
     sessionId,
     pdfPainterHostInstanceControllerHook,
     pdfPainterControllerHook

--- a/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
@@ -27,7 +27,7 @@ export default function ParticipantViewer(props: ViewerPropType) {
     },
   });
   const pdfPainterControllerHook = usePDFPainterController({
-    painterId: `${sessionName}_${pdfDocument.fileId}`,
+    painterId: `${sessionId}_${pdfDocument.fileId}`,
   });
   const pdfPainterHostInstanceControllerHook = usePDFPainterInstanceController({
     editorId: "Host",

--- a/packages/front-end/app/view/[sessionId]/_hooks/useBatchSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useBatchSocket.ts
@@ -28,12 +28,10 @@ const INTERVAL_TIME = 100; // fps = 1000 / INTERVAL_TIME
  */
 export const useBatchSocket = ({
   socket,
-  userId,
   roomId,
   pageIndex,
 }: {
   socket: Socket | null;
-  userId: number;
   roomId: number | string;
   pageIndex: number;
 }) => {
@@ -176,6 +174,6 @@ export const useBatchSocket = ({
     return () => {
       clearInterval(intervalId);
     };
-  }, [pageIndex, processBatchQueue, roomId, socket, userId]);
+  }, [pageIndex, processBatchQueue, roomId, socket]);
   return { queueRef, pushChanges };
 };

--- a/packages/front-end/app/view/[sessionId]/_hooks/useBatchSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useBatchSocket.ts
@@ -30,10 +30,12 @@ export const useBatchSocket = ({
   socket,
   userId,
   roomId,
+  pageIndex,
 }: {
   socket: Socket | null;
   userId: number;
   roomId: number | string;
+  pageIndex: number;
 }) => {
   const queueRef = useRef<{
     [key in RecordId<any>]: ElementType[];
@@ -148,7 +150,7 @@ export const useBatchSocket = ({
     const intervalId = setInterval(() => {
       const dataFormat = processBatchQueue();
       const messageBody = {
-        index: 1,
+        index: pageIndex,
         userId: userId,
         roomId: roomId,
       };
@@ -175,6 +177,6 @@ export const useBatchSocket = ({
     return () => {
       clearInterval(intervalId);
     };
-  }, [processBatchQueue, roomId, socket, userId]);
+  }, [pageIndex, processBatchQueue, roomId, socket, userId]);
   return { queueRef, pushChanges };
 };

--- a/packages/front-end/app/view/[sessionId]/_hooks/useBatchSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useBatchSocket.ts
@@ -151,7 +151,6 @@ export const useBatchSocket = ({
       const dataFormat = processBatchQueue();
       const messageBody = {
         index: pageIndex,
-        userId: userId,
         roomId: roomId,
       };
       if (dataFormat.added.length > 0) {

--- a/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
@@ -1,16 +1,18 @@
 import { useEffect, useState } from "react";
 import { io, Socket } from "socket.io-client";
-import { createTLStore, defaultShapeUtils } from "tldraw";
 import { useBatchSocket } from "./useBatchSocket";
+import { PDFPainterInstanceControllerHook } from "@/PaintPDF/components";
 
-export const useHostSocket = (userId: number, roomId: number | string) => {
+export const useHostSocket = (
+  userId: number,
+  roomId: number | string,
+  pdfPainterInstanceControllerHook: PDFPainterInstanceControllerHook
+) => {
   const [socket, setSocket] = useState<Socket | null>(null);
   const { pushChanges } = useBatchSocket({ socket, userId, roomId });
+  const { pdfPainterInstanceController } = pdfPainterInstanceControllerHook;
 
-  const [store] = useState(() => {
-    const store = createTLStore({ shapeUtils: [...defaultShapeUtils] });
-    return store;
-  });
+  const editor = pdfPainterInstanceController.getEditor();
 
   useEffect(() => {
     setSocket(
@@ -22,6 +24,8 @@ export const useHostSocket = (userId: number, roomId: number | string) => {
 
   useEffect(() => {
     if (socket === null) return;
+    if (editor === null) return;
+    const { store } = editor;
 
     socket.on("connect", () => {
       console.log("Connected to WebSocket server");
@@ -39,6 +43,5 @@ export const useHostSocket = (userId: number, roomId: number | string) => {
     return () => {
       socket.disconnect();
     };
-  }, [pushChanges, roomId, socket, store, userId]);
-  return store;
+  }, [editor, pushChanges, roomId, socket, userId]);
 };

--- a/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
@@ -36,7 +36,7 @@ export const useHostSocket = (
     socket.on("connect", () => {
       console.log("Connected to WebSocket server");
     });
-    socket.emit("createRoom", { userId: userId, roomId: roomId });
+    socket.emit("createRoom", { roomId: roomId });
     socket.on("userList", (userList: any) => {
       console.log({ userList });
     });

--- a/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
@@ -5,6 +5,8 @@ import {
   PDFPainterControllerHook,
   PDFPainterInstanceControllerHook,
 } from "@/PaintPDF/components";
+import { socketAtom } from "@/client/socketAtom";
+import { useAtom } from "jotai";
 
 export const useHostSocket = (
   userId: number,
@@ -12,21 +14,13 @@ export const useHostSocket = (
   pdfPainterInstanceControllerHook: PDFPainterInstanceControllerHook,
   pdfPainterControllerHook: PDFPainterControllerHook
 ) => {
-  const [socket, setSocket] = useState<Socket | null>(null);
+  const [socket] = useAtom(socketAtom);
   const { pdfPainterController } = pdfPainterControllerHook;
   const { pdfPainterInstanceController } = pdfPainterInstanceControllerHook;
   const pageIndex = pdfPainterController.getPageIndex();
   const { pushChanges } = useBatchSocket({ socket, userId, roomId, pageIndex });
 
   const editor = pdfPainterInstanceController.getEditor();
-
-  useEffect(() => {
-    setSocket(
-      io(process.env.NEXT_PUBLIC_SOCKET_SERVER as string, {
-        withCredentials: true,
-      })
-    );
-  }, []);
 
   useEffect(() => {
     if (socket === null) return;

--- a/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
@@ -2,7 +2,9 @@ import { useEffect, useState } from "react";
 import { io, Socket } from "socket.io-client";
 import { useBatchSocket } from "./useBatchSocket";
 import {
+  PDFPainterController,
   PDFPainterControllerHook,
+  PDFPainterInstanceController,
   PDFPainterInstanceControllerHook,
 } from "@/PaintPDF/components";
 import { socketAtom } from "@/client/socketAtom";
@@ -10,12 +12,10 @@ import { useAtom } from "jotai";
 
 export const useHostSocket = (
   roomId: number | string,
-  pdfPainterInstanceControllerHook: PDFPainterInstanceControllerHook,
-  pdfPainterControllerHook: PDFPainterControllerHook
+  pdfPainterInstanceController: PDFPainterInstanceController,
+  pdfPainterController: PDFPainterController
 ) => {
   const [socket] = useAtom(socketAtom);
-  const { pdfPainterController } = pdfPainterControllerHook;
-  const { pdfPainterInstanceController } = pdfPainterInstanceControllerHook;
   const pageIndex = pdfPainterController.getPageIndex();
   const { pushChanges } = useBatchSocket({ socket, roomId, pageIndex });
 

--- a/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
@@ -40,8 +40,5 @@ export const useHostSocket = (
       },
       { source: "user", scope: "document" }
     );
-    return () => {
-      socket.disconnect();
-    };
   }, [editor, pushChanges, roomId, socket, userId]);
 };

--- a/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
@@ -9,7 +9,6 @@ import { socketAtom } from "@/client/socketAtom";
 import { useAtom } from "jotai";
 
 export const useHostSocket = (
-  userId: number,
   roomId: number | string,
   pdfPainterInstanceControllerHook: PDFPainterInstanceControllerHook,
   pdfPainterControllerHook: PDFPainterControllerHook
@@ -18,7 +17,7 @@ export const useHostSocket = (
   const { pdfPainterController } = pdfPainterControllerHook;
   const { pdfPainterInstanceController } = pdfPainterInstanceControllerHook;
   const pageIndex = pdfPainterController.getPageIndex();
-  const { pushChanges } = useBatchSocket({ socket, userId, roomId, pageIndex });
+  const { pushChanges } = useBatchSocket({ socket, roomId, pageIndex });
 
   const editor = pdfPainterInstanceController.getEditor();
 
@@ -40,5 +39,5 @@ export const useHostSocket = (
       },
       { source: "user", scope: "document" }
     );
-  }, [editor, pushChanges, roomId, socket, userId]);
+  }, [editor, pushChanges, roomId, socket]);
 };

--- a/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
@@ -1,16 +1,22 @@
 import { useEffect, useState } from "react";
 import { io, Socket } from "socket.io-client";
 import { useBatchSocket } from "./useBatchSocket";
-import { PDFPainterInstanceControllerHook } from "@/PaintPDF/components";
+import {
+  PDFPainterControllerHook,
+  PDFPainterInstanceControllerHook,
+} from "@/PaintPDF/components";
 
 export const useHostSocket = (
   userId: number,
   roomId: number | string,
-  pdfPainterInstanceControllerHook: PDFPainterInstanceControllerHook
+  pdfPainterInstanceControllerHook: PDFPainterInstanceControllerHook,
+  pdfPainterControllerHook: PDFPainterControllerHook
 ) => {
   const [socket, setSocket] = useState<Socket | null>(null);
-  const { pushChanges } = useBatchSocket({ socket, userId, roomId });
+  const { pdfPainterController } = pdfPainterControllerHook;
   const { pdfPainterInstanceController } = pdfPainterInstanceControllerHook;
+  const pageIndex = pdfPainterController.getPageIndex();
+  const { pushChanges } = useBatchSocket({ socket, userId, roomId, pageIndex });
 
   const editor = pdfPainterInstanceController.getEditor();
 

--- a/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
@@ -42,13 +42,11 @@ export const useParticipantSocket = (
   }, [roomId, socket]);
 
   useEffect(() => {
-    console.error("pageIndex in useEffect", pageIndex);
     if (socket === null) return;
 
     socket.on(
       "getAddedDraw",
       (message: { data: TLRecord[]; index: number }) => {
-        console.log(`current:${pageIndex},received:${message.index}`);
         pageIndex === message.index
           ? pdfPainterInstanceController.addPaintElement(message.data)
           : addDrawCache(message.index, message.data);

--- a/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
@@ -6,6 +6,7 @@ import {
   PDFPainterControllerHook,
   PDFPainterInstanceControllerHook,
 } from "@/PaintPDF/components";
+import { useReceiveDrawCache } from "./useReceiveDrawCache";
 
 export const useParticipantSocket = (
   userId: number,
@@ -15,6 +16,8 @@ export const useParticipantSocket = (
 ) => {
   const { pdfPainterController } = pdfPainterControllerHook;
   const { pdfPainterInstanceController } = pdfPainterInstanceControllerHook;
+  const { removeDrawCache, addDrawCache, updateDrawCache } =
+    useReceiveDrawCache();
   const pageIndex = pdfPainterController.getPageIndex();
 
   useEffect(() => {

--- a/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
@@ -34,17 +34,17 @@ export const useParticipantSocket = (
     socket.on(
       "getAddedDraw",
       (message: { data: TLRecord[]; index: number }) => {
-        if (pageIndex === message.index) {
-          pdfPainterInstanceController.addPaintElement(message.data);
-        }
+        pageIndex === message.index
+          ? pdfPainterInstanceController.addPaintElement(message.data)
+          : addDrawCache(pageIndex, message.data);
       }
     );
     socket.on(
       "getRemovedDraw",
       (message: { data: RecordId<any>[]; index: number }) => {
-        if (pageIndex === message.index) {
-          pdfPainterInstanceController.removePaintElement(message.data);
-        }
+        pageIndex === message.index
+          ? pdfPainterInstanceController.removePaintElement(message.data)
+          : removeDrawCache(pageIndex, message.data);
       }
     );
     socket.on(
@@ -59,6 +59,8 @@ export const useParticipantSocket = (
                 return integralRecord(record, update);
               }
             );
+          } else {
+            updateDrawCache(pageIndex, message.data);
           }
         });
       }
@@ -66,5 +68,13 @@ export const useParticipantSocket = (
     return () => {
       socket.disconnect();
     };
-  }, [pageIndex, pdfPainterInstanceController, roomId, userId]);
+  }, [
+    addDrawCache,
+    pageIndex,
+    pdfPainterInstanceController,
+    removeDrawCache,
+    roomId,
+    updateDrawCache,
+    userId,
+  ]);
 };

--- a/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
@@ -11,7 +11,6 @@ import { socketAtom } from "@/client/socketAtom";
 import { useAtom } from "jotai";
 
 export const useParticipantSocket = (
-  userId: number,
   roomId: number | string,
   pdfPainterInstanceControllerHook: PDFPainterInstanceControllerHook,
   pdfPainterControllerHook: PDFPainterControllerHook

--- a/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
@@ -1,22 +1,19 @@
 import { useEffect, useState } from "react";
-import { io, Socket } from "socket.io-client";
 import { RecordId, TLRecord } from "tldraw";
-import { integralRecord } from "../_utils/integralRecord";
 import {
-  PDFPainterControllerHook,
-  PDFPainterInstanceControllerHook,
+  PDFPainterController,
+  PDFPainterInstanceController,
 } from "@/PaintPDF/components";
 import { useReceiveDrawCache } from "./useReceiveDrawCache";
 import { socketAtom } from "@/client/socketAtom";
 import { useAtom } from "jotai";
+import { integralRecord } from "../_utils/integralRecord";
 
 export const useParticipantSocket = (
   roomId: number | string,
-  pdfPainterInstanceControllerHook: PDFPainterInstanceControllerHook,
-  pdfPainterControllerHook: PDFPainterControllerHook
+  pdfPainterInstanceController: PDFPainterInstanceController,
+  pdfPainterController: PDFPainterController
 ) => {
-  const { pdfPainterController } = pdfPainterControllerHook;
-  const { pdfPainterInstanceController } = pdfPainterInstanceControllerHook;
   const editor = pdfPainterInstanceController.getEditor();
   const {
     removeDrawCache,
@@ -30,7 +27,7 @@ export const useParticipantSocket = (
   // useEffect는 일단 호출되므로 내 페이지가 0인 경우에도 작동 -> cache에 삽입데이터가 반영됨?
   // 아 왜 pageIndex가 순간 message.index로 바뀌는거지?
   useEffect(() => {
-    // setEditorFromDrawCache(pageIndex);
+    setEditorFromDrawCache(pageIndex);
   }, [pageIndex, setEditorFromDrawCache]);
 
   useEffect(() => {
@@ -45,46 +42,49 @@ export const useParticipantSocket = (
   }, [roomId, socket]);
 
   useEffect(() => {
-    console.error("pageIndex in useEffect",pageIndex)
+    console.error("pageIndex in useEffect", pageIndex);
     if (socket === null) return;
+
     socket.on(
       "getAddedDraw",
       (message: { data: TLRecord[]; index: number }) => {
         console.log(`current:${pageIndex},received:${message.index}`);
-        // pageIndex === message.index
-        //   ? pdfPainterInstanceController.addPaintElement(message.data)
-        //   : addDrawCache(message.index, message.data);
+        pageIndex === message.index
+          ? pdfPainterInstanceController.addPaintElement(message.data)
+          : addDrawCache(message.index, message.data);
       }
     );
     socket.on(
       "getRemovedDraw",
       (message: { data: RecordId<any>[]; index: number }) => {
-        console.log(`current:${pageIndex},received:${message.index}`);
-        // pageIndex === message.index
-        //   ? pdfPainterInstanceController.removePaintElement(message.data)
-        //   : removeDrawCache(message.index, message.data);
+        pageIndex === message.index
+          ? pdfPainterInstanceController.removePaintElement(message.data)
+          : removeDrawCache(message.index, message.data);
       }
     );
     socket.on(
       "getUpdatedDraw",
       (message: { data: TLRecord[]; index: number }) => {
-        console.log(`current:${pageIndex},received:${message.index}`);
-        // 처리 관련 로직이 페이지가 뛰는거에 영향을 주진 않음
-        // const updates = message.data;
-        // updates.forEach((update) => {
-        //   if (pageIndex === message.index) {
-        //     pdfPainterInstanceController.updatePaintElementByGenerator(
-        //       update.id,
-        //       (record) => {
-        //         return integralRecord(record, update);
-        //       }
-        //     );
-        //   } else {
-        //     updateDrawCache(message.index, message.data);
-        //   }
-        // });
+        const updates = message.data;
+        updates.forEach((update) => {
+          if (pageIndex === message.index) {
+            pdfPainterInstanceController.updatePaintElementByGenerator(
+              update.id,
+              (record) => {
+                return integralRecord(record, update);
+              }
+            );
+          } else {
+            updateDrawCache(message.index, message.data);
+          }
+        });
       }
     );
+    return () => {
+      socket.off("getAddedDraw");
+      socket.off("getRemovedDraw");
+      socket.off("getUpdatedDraw");
+    };
   }, [
     addDrawCache,
     pageIndex,

--- a/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
@@ -41,7 +41,7 @@ export const useParticipantSocket = (
     socket.on("connect", () => {
       console.log("Connected to WebSocket server");
     });
-    socket.emit("joinRoom", { userId: userId, roomId: roomId });
+    socket.emit("joinRoom", { roomId: roomId });
     socket.on("userList", (userList: any) => {
       console.log({ userList });
     });

--- a/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
@@ -34,6 +34,7 @@ export const useParticipantSocket = (
     const pageDrawMap = drawCacheRef.current.get(pageIndex);
     if (pageDrawMap === undefined || editor === null) return;
     editor.store.put(Array.from(pageDrawMap.values()));
+    drawCacheRef.current.delete(pageIndex);
   }, [drawCacheRef, pageIndex, editor]);
 
   useEffect(() => {

--- a/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
@@ -25,8 +25,15 @@ export const useParticipantSocket = (
 
   useEffect(() => {
     const pageDrawMap = drawCacheRef.current.get(pageIndex);
+    console.log({ drawCache: drawCacheRef.current, pageDrawMap, pageIndex });
     if (pageDrawMap === undefined || editor === null) return;
-    editor.store.put(Array.from(pageDrawMap.values()));
+    console.log(Array.from(pageDrawMap.values()));
+    editor.store.put(
+      Array.from(pageDrawMap.values()).filter((value) => {
+        const record = value as { type: string } & typeof value;
+        return record.type !== undefined;
+      })
+    );
     drawCacheRef.current.delete(pageIndex);
   }, [drawCacheRef, pageIndex, editor]);
 
@@ -49,7 +56,7 @@ export const useParticipantSocket = (
         console.warn("ADDED");
         pageIndex === message.index
           ? pdfPainterInstanceController.addPaintElement(message.data)
-          : addDrawCache(pageIndex, message.data);
+          : addDrawCache(message.index, message.data);
       }
     );
     socket.on(
@@ -58,7 +65,7 @@ export const useParticipantSocket = (
         console.warn("REMOVE");
         pageIndex === message.index
           ? pdfPainterInstanceController.removePaintElement(message.data)
-          : removeDrawCache(pageIndex, message.data);
+          : removeDrawCache(message.index, message.data);
       }
     );
     socket.on(
@@ -75,7 +82,7 @@ export const useParticipantSocket = (
               }
             );
           } else {
-            updateDrawCache(pageIndex, message.data);
+            updateDrawCache(message.index, message.data);
           }
         });
       }

--- a/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
@@ -40,6 +40,10 @@ export const useParticipantSocket = (
     socket.on("userList", (userList: any) => {
       console.log({ userList });
     });
+  }, [roomId, socket]);
+
+  useEffect(() => {
+    if (socket === null) return;
     socket.on(
       "getAddedDraw",
       (message: { data: TLRecord[]; index: number }) => {
@@ -82,9 +86,7 @@ export const useParticipantSocket = (
     pageIndex,
     pdfPainterInstanceController,
     removeDrawCache,
-    roomId,
     socket,
     updateDrawCache,
-    userId,
   ]);
 };

--- a/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
@@ -77,9 +77,6 @@ export const useParticipantSocket = (
         });
       }
     );
-    return () => {
-      socket.disconnect();
-    };
   }, [
     addDrawCache,
     pageIndex,

--- a/packages/front-end/app/view/[sessionId]/_hooks/useReceiveDrawCache.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useReceiveDrawCache.ts
@@ -3,7 +3,6 @@ import { Editor, RecordId, TLRecord } from "tldraw";
 import { integralRecord } from "../_utils/integralRecord";
 
 export const useReceiveDrawCache = () => {
-  const tmp = new Map(new Map<RecordId<any>, TLRecord>());
   const drawCacheRef = useRef<Map<number, Map<RecordId<any>, TLRecord>>>(
     new Map()
   );
@@ -34,5 +33,5 @@ export const useReceiveDrawCache = () => {
     },
     []
   );
-  return { removeDrawCache, addDrawCache, updateDrawCache };
+  return { removeDrawCache, addDrawCache, updateDrawCache, drawCacheRef };
 };

--- a/packages/front-end/app/view/[sessionId]/_hooks/useReceiveDrawCache.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useReceiveDrawCache.ts
@@ -6,8 +6,14 @@ export const useReceiveDrawCache = () => {
   const drawCacheRef = useRef<Map<number, Map<RecordId<any>, TLRecord>>>(
     new Map()
   );
+  const initCachePageIndex = (pageIndex: number) => {
+    if (drawCacheRef.current.get(pageIndex) === undefined) {
+      drawCacheRef.current.set(pageIndex, new Map());
+    }
+  };
   const removeDrawCache = useCallback(
     (pageIndex: number, ids: RecordId<any>[]) => {
+      initCachePageIndex(pageIndex);
       ids.forEach((id) => {
         drawCacheRef.current.get(pageIndex)?.delete(id);
       });
@@ -16,6 +22,7 @@ export const useReceiveDrawCache = () => {
   );
   const addDrawCache = useCallback(
     (pageIndex: number, elements: TLRecord[]) => {
+      initCachePageIndex(pageIndex);
       elements.forEach((element) => {
         drawCacheRef.current.get(pageIndex)?.set(element.id, element);
       });
@@ -24,8 +31,16 @@ export const useReceiveDrawCache = () => {
   );
   const updateDrawCache = useCallback(
     (pageIndex: number, elements: TLRecord[]) => {
+      initCachePageIndex(pageIndex);
       elements.forEach((element) => {
         const prevRecord = drawCacheRef.current.get(pageIndex)?.get(element.id);
+        if (prevRecord === undefined) {
+          console.log(
+            `${pageIndex} 페이지에서 이 그리기:${element.id} 처리 불가`,
+            drawCacheRef.current.get(pageIndex)?.get(element.id),
+            drawCacheRef.current.get(pageIndex)
+          );
+        }
         drawCacheRef.current
           .get(pageIndex)
           ?.set(element.id, integralRecord(prevRecord, element));

--- a/packages/front-end/app/view/[sessionId]/_hooks/useReceiveDrawCache.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useReceiveDrawCache.ts
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useCallback, useRef } from "react";
 import { Editor, RecordId, TLRecord } from "tldraw";
 import { integralRecord } from "../_utils/integralRecord";
 
@@ -7,23 +7,32 @@ export const useReceiveDrawCache = () => {
   const drawCacheRef = useRef<Map<number, Map<RecordId<any>, TLRecord>>>(
     new Map()
   );
-  const removeDrawCache = (pageIndex: number, ids: RecordId<any>[]) => {
-    ids.forEach((id) => {
-      drawCacheRef.current.get(pageIndex)?.delete(id);
-    });
-  };
-  const addDrawCache = (pageIndex: number, elements: TLRecord[]) => {
-    elements.forEach((element) => {
-      drawCacheRef.current.get(pageIndex)?.set(element.id, element);
-    });
-  };
-  const updateDrawCache = (pageIndex: number, elements: TLRecord[]) => {
-    elements.forEach((element) => {
-      const prevRecord = drawCacheRef.current.get(pageIndex)?.get(element.id);
-      drawCacheRef.current
-        .get(pageIndex)
-        ?.set(element.id, integralRecord(prevRecord, element));
-    });
-  };
+  const removeDrawCache = useCallback(
+    (pageIndex: number, ids: RecordId<any>[]) => {
+      ids.forEach((id) => {
+        drawCacheRef.current.get(pageIndex)?.delete(id);
+      });
+    },
+    []
+  );
+  const addDrawCache = useCallback(
+    (pageIndex: number, elements: TLRecord[]) => {
+      elements.forEach((element) => {
+        drawCacheRef.current.get(pageIndex)?.set(element.id, element);
+      });
+    },
+    []
+  );
+  const updateDrawCache = useCallback(
+    (pageIndex: number, elements: TLRecord[]) => {
+      elements.forEach((element) => {
+        const prevRecord = drawCacheRef.current.get(pageIndex)?.get(element.id);
+        drawCacheRef.current
+          .get(pageIndex)
+          ?.set(element.id, integralRecord(prevRecord, element));
+      });
+    },
+    []
+  );
   return { removeDrawCache, addDrawCache, updateDrawCache };
 };

--- a/packages/front-end/app/view/[sessionId]/_hooks/useReceiveDrawCache.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useReceiveDrawCache.ts
@@ -43,7 +43,6 @@ export const useReceiveDrawCache = (editor: Editor | null) => {
   );
   const setEditorFromDrawCache = useCallback(
     (pageIndex: number) => {
-      console.error("setEditorFromCache",drawCacheRef.current,pageIndex)
       const pageDrawMap = drawCacheRef.current.get(pageIndex);
       if (pageDrawMap === undefined || editor === null) return;
       // editor관련 코드가 pageIndex를 순회하진 않음
@@ -52,7 +51,7 @@ export const useReceiveDrawCache = (editor: Editor | null) => {
           const record = value as { type: string | undefined } & typeof value;
           if (record.type === undefined) {
             const recordFromEditor = editor.store.get(value.id);
-            console.warn("WEIRD RECORD", {
+            console.warn("WEIRD RECORD! but don't worry. It will works well...maybe", {
               record: integralRecord(recordFromEditor, value),
             });
             return integralRecord(recordFromEditor, value);

--- a/packages/front-end/app/view/[sessionId]/_hooks/useReceiveDrawCache.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useReceiveDrawCache.ts
@@ -1,0 +1,29 @@
+import { useRef } from "react";
+import { Editor, RecordId, TLRecord } from "tldraw";
+import { integralRecord } from "../_utils/integralRecord";
+
+export const useReceiveDrawCache = () => {
+  const tmp = new Map(new Map<RecordId<any>, TLRecord>());
+  const drawCacheRef = useRef<Map<number, Map<RecordId<any>, TLRecord>>>(
+    new Map()
+  );
+  const removeDrawCache = (pageIndex: number, ids: RecordId<any>[]) => {
+    ids.forEach((id) => {
+      drawCacheRef.current.get(pageIndex)?.delete(id);
+    });
+  };
+  const addDrawCache = (pageIndex: number, elements: TLRecord[]) => {
+    elements.forEach((element) => {
+      drawCacheRef.current.get(pageIndex)?.set(element.id, element);
+    });
+  };
+  const updateDrawCache = (pageIndex: number, elements: TLRecord[]) => {
+    elements.forEach((element) => {
+      const prevRecord = drawCacheRef.current.get(pageIndex)?.get(element.id);
+      drawCacheRef.current
+        .get(pageIndex)
+        ?.set(element.id, integralRecord(prevRecord, element));
+    });
+  };
+  return { removeDrawCache, addDrawCache, updateDrawCache };
+};

--- a/packages/front-end/app/view/[sessionId]/_types/ViewerType.ts
+++ b/packages/front-end/app/view/[sessionId]/_types/ViewerType.ts
@@ -1,0 +1,5 @@
+import { SessionResponseDto } from "@/schema/backend.schema";
+
+export interface ViewerPropType extends SessionResponseDto {
+  userId: number;
+}

--- a/packages/front-end/app/view/[sessionId]/page.tsx
+++ b/packages/front-end/app/view/[sessionId]/page.tsx
@@ -6,6 +6,10 @@ import HostViewer from "./_components/HostViewer";
 import { useQueries } from "@tanstack/react-query";
 import { apiClient } from "@/utils/axios";
 import ParticipantViewer from "./_components/ParticipantViewer";
+import { useAtom, useSetAtom } from "jotai";
+import { socketAtom } from "@/client/socketAtom";
+import { useEffect } from "react";
+import { io } from "socket.io-client";
 
 export default function Page({ params }: { params: { sessionId: string } }) {
   const [userQuery, sessionQuery] = useQueries({
@@ -25,6 +29,15 @@ export default function Page({ params }: { params: { sessionId: string } }) {
       },
     ],
   });
+  const [, setSocket] = useAtom(socketAtom);
+  useEffect(() => {
+    const newSocket = io(process.env.NEXT_PUBLIC_SOCKET_SERVER, {
+      withCredentials: true,
+    });
+    setSocket(newSocket);
+    return () => newSocket.disconnect();
+  }, [setSocket]);
+
   if (userQuery.isLoading || sessionQuery.isLoading) {
     return <h1>로딩...</h1>;
   }

--- a/packages/front-end/app/view/[sessionId]/page.tsx
+++ b/packages/front-end/app/view/[sessionId]/page.tsx
@@ -28,16 +28,16 @@ export default function Page({ params }: { params: { sessionId: string } }) {
   if (userQuery.isLoading || sessionQuery.isLoading) {
     return <h1>로딩...</h1>;
   }
-  const userData = userQuery.data?.data;
-  const sessionData = sessionQuery.data?.data;
-  const userId = userData?.userId;
-  const isHost = userData?.userId === sessionData?.hostId;
-  if (userId === undefined) {
-    return <h1>로딩...</h1>;
+  if (userQuery.data === undefined || sessionQuery.data === undefined) {
+    return <></>;
   }
+  const userData = userQuery.data.data;
+  const sessionData = sessionQuery.data.data;
+  const userId = userData.userId;
+  const isHost = userData.userId === sessionData.hostId;
   return isHost ? (
-    <HostViewer params={{ ...params, userId: userId }} />
+    <HostViewer {...{ ...sessionData, userId: userId }} />
   ) : (
-    <ParticipantViewer params={{ ...params, userId: userId }} />
+    <ParticipantViewer {...{ ...sessionData, userId: userId }} />
   );
 }

--- a/packages/front-end/app/view/[sessionId]/page.tsx
+++ b/packages/front-end/app/view/[sessionId]/page.tsx
@@ -31,11 +31,13 @@ export default function Page({ params }: { params: { sessionId: string } }) {
   });
   const [, setSocket] = useAtom(socketAtom);
   useEffect(() => {
-    const newSocket = io(process.env.NEXT_PUBLIC_SOCKET_SERVER, {
+    const newSocket = io(process.env.NEXT_PUBLIC_SOCKET_SERVER as string, {
       withCredentials: true,
     });
     setSocket(newSocket);
-    return () => newSocket.disconnect();
+    return () => {
+      newSocket.disconnect();
+    };
   }, [setSocket]);
 
   if (userQuery.isLoading || sessionQuery.isLoading) {

--- a/packages/front-end/client/socketAtom.tsx
+++ b/packages/front-end/client/socketAtom.tsx
@@ -1,0 +1,4 @@
+import { Socket } from "socket.io-client";
+import { atom } from "jotai";
+
+export const socketAtom = atom<null | Socket>(null);

--- a/packages/socket-server/src/socket/socket.gateway.ts
+++ b/packages/socket-server/src/socket/socket.gateway.ts
@@ -59,7 +59,7 @@ export class SocketGateway
 
   async afterInit(server: Server) {
     server.on('connection', (socket: Socket) => {
-      console.log(socket.id);
+      console.log({ socketId: socket.id }, 'afterInit');
     });
   }
 
@@ -68,6 +68,7 @@ export class SocketGateway
     if (!userId) client.disconnect(true);
     this.clientUserId[client.id] = userId;
     this.clients.add(client);
+    console.log({ clientId: client.id, userId }, 'handleConnection');
     return;
   }
 
@@ -83,8 +84,10 @@ export class SocketGateway
     }
     client.disconnect(true);
     this.clients.delete(client);
-    console.log('disconnected');
-    console.log(this.roomUsers, this.roomHost);
+    console.log(
+      { roomUsers: this.roomUsers, roomHost: this.roomHost },
+      'disconnect',
+    );
   }
 
   @SubscribeMessage('createRoom')

--- a/packages/socket-server/src/socket/socket.gateway.ts
+++ b/packages/socket-server/src/socket/socket.gateway.ts
@@ -56,6 +56,19 @@ export class SocketGateway
     }
     return userId;
   }
+  private debugActiveRooms(prefix: string = '') {
+    const rooms = this.server.of('/').adapter.rooms;
+    const roomInfo = [];
+
+    rooms.forEach((clients, roomName) => {
+      // 소켓 ID와 동일한 방은 필터링하고, 실제 방만 확인
+      if (!this.server.sockets.sockets.get(roomName)) {
+        roomInfo.push({ roomName, clients: Array.from(clients) }); // key와 value 출력
+      }
+    });
+
+    console.log(prefix, 'debug active rooms:', roomInfo);
+  }
 
   async afterInit(server: Server) {
     server.on('connection', (socket: Socket) => {
@@ -114,6 +127,7 @@ export class SocketGateway
       roomId,
       userList: Array.from(this.roomUsers[roomId]),
     });
+    this.debugActiveRooms('createRoom');
   }
 
   @SubscribeMessage('joinRoom')
@@ -137,6 +151,7 @@ export class SocketGateway
       roomId,
       userList: Array.from(this.roomUsers[roomId]),
     });
+    this.debugActiveRooms('joinRoom');
   }
 
   @SubscribeMessage('sendPageNumber')


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 [#]
close #378 
close #380 
close #390
## 📄 개요
- PaintPDF를 적용
- page에서 필요한 api fetching 후 viewer에 props로 전달
- 전역상태관리를 이용한 소켓 인스턴스 생명 관리
  - 다른 useEffect clean-up func내 disconnect를 제거해 참여자 소켓이 연결이 계속 끊어지는 버그 해결
- joinRoom을 여러번 호출 안하게 변경
- 다른 페이지의 경우 useRef를 통한 캐시 레이어 구현
  - 단 현재는 호스트가 필기를 update하는 중 참여자가 페이지인덱스를 바꾼다면 반영 안됨(추후 구현)
  - 따라서 일부 데이터는 필요한 Record Field가 undefined고, 반영 안되게 햇음
  - 페이지가 바뀜에 따라 반영이되고 반영된건 메모리를 해제해 누수를 방지함
## 🔁 변경 사항
- useHostSocket, useBatchSocket, useParticipantSocket을 PaintPDF api를 이용한 코드로 변경
- HostViewer 및 Participant Viewer에서 GET session?sessionId= 를 중복 fetching할 필요 없다고 생각해 page에서 유저랑 세션 정보만 불러옴
- 참여자도 state를 이용해 socket 인스턴스 관리해 생명주기 제어
- 참여자가 보고있는 페이지와 다른 다른 페이지의 필기를 받는 로직을 ref & map를 이용한 cache 구현
  - 아마 key의 값이 batchQueue와 달리 매우 많을 것이라 이참에 map 적용
  - 로컬스토리지 쓰기엔 빈번한 write가 넘 자주 일어남
 

## 📸 동작 화면 스크린샷

## 👀 기타 논의 사항
- 참여자의 경우 POST /user/session/${sessionId}/join 을 세션 정보 불러오기 전에 해야하는데 이것이 가능한가? 이전에 호스트인지 참여자인지 거를려면 session과 user 정보를 불러와야하는데