### PR TITLE
fix: load editor snapshot with mergeRemoteChanges

### DIFF
--- a/packages/front-end/PaintPDF/components/PDFPainter/hooks/usePDFPainterController.ts
+++ b/packages/front-end/PaintPDF/components/PDFPainter/hooks/usePDFPainterController.ts
@@ -3,263 +3,307 @@ import { Editor } from "tldraw";
 import { usePDFViewerController } from "../../PDF";
 
 import { ExternalAssetStore } from "../../Painter/types";
-import { PaintMode, EditorSnapshot, PDFPainterController, PDFPainterControllerHook } from "../types";
+import {
+  PaintMode,
+  EditorSnapshot,
+  PDFPainterController,
+  PDFPainterControllerHook,
+} from "../types";
 
 import CleanPainterSnapshot from "../../../assets/data/snapshot.json";
 
 export const usePDFPainterController = ({
-	painterId,
-	externalAssetStore = null,
+  painterId,
+  externalAssetStore = null,
 }: {
-	painterId: string;
-	externalAssetStore?: ExternalAssetStore | null;
+  painterId: string;
+  externalAssetStore?: ExternalAssetStore | null;
 }): PDFPainterControllerHook => {
-	const { pdfViewerController, onPdfDocumentChange, onPdfPageChange, onPdfItemClick, onPdfMouseMoveEvent, onPdfWheelEvent } = usePDFViewerController();
+  const {
+    pdfViewerController,
+    onPdfDocumentChange,
+    onPdfPageChange,
+    onPdfItemClick,
+    onPdfMouseMoveEvent,
+    onPdfWheelEvent,
+  } = usePDFViewerController();
 
-	const [paintMode, setPaintMode] = useState<PaintMode>("default");
+  const [paintMode, setPaintMode] = useState<PaintMode>("default");
 
-	const editors = useRef<{ [editorId: string]: Editor }>({});
+  const editors = useRef<{ [editorId: string]: Editor }>({});
 
-	const currentPageId = useRef<number | null>(null);
+  const currentPageId = useRef<number | null>(null);
 
-	useEffect(() => {
-		pdfViewerController.setDragModeEnabled(paintMode === "move");
-		Object.values(editors.current).forEach((editor: Editor) => {
-			editor.selectNone();
-		});
-	}, [pdfViewerController, paintMode]);
+  useEffect(() => {
+    pdfViewerController.setDragModeEnabled(paintMode === "move");
+    Object.values(editors.current).forEach((editor: Editor) => {
+      editor.selectNone();
+    });
+  }, [pdfViewerController, paintMode]);
 
-	const getEditor = useCallback((editorId: string): Editor | null => {
-		if (editorId in editors.current) {
-			return editors.current[editorId];
-		}
-		return null;
-	}, []);
+  const getEditor = useCallback((editorId: string): Editor | null => {
+    if (editorId in editors.current) {
+      return editors.current[editorId];
+    }
+    return null;
+  }, []);
 
-	const getSnapshotId = useCallback(
-		(editorId: string, pdfPageIndex: number) => {
-			return `${painterId}_${editorId}_${pdfPageIndex}`;
-		},
-		[painterId],
-	);
+  const getSnapshotId = useCallback(
+    (editorId: string, pdfPageIndex: number) => {
+      return `${painterId}_${editorId}_${pdfPageIndex}`;
+    },
+    [painterId]
+  );
 
-	const getEditorSnapshotFromStorage = useCallback(
-		(editorId: string, pageIndex: number): EditorSnapshot | null => {
-			const snapshotId = getSnapshotId(editorId, pageIndex);
-			console.log(`[Editor: ${editorId} - Page: ${pageIndex}] Get Editor Snapshot: ${snapshotId}`);
-			const data = localStorage.getItem(snapshotId);
-			if (data !== null) {
-				try {
-					return JSON.parse(data);
-				} catch (e) {
-					console.log(`[Editor: ${editorId} - Page: ${pageIndex}] Invalid Snapshot: ${snapshotId}`);
-					console.log(e);
-				}
-			}
-			return null;
-		},
-		[getSnapshotId],
-	);
+  const getEditorSnapshotFromStorage = useCallback(
+    (editorId: string, pageIndex: number): EditorSnapshot | null => {
+      const snapshotId = getSnapshotId(editorId, pageIndex);
+      console.log(
+        `[Editor: ${editorId} - Page: ${pageIndex}] Get Editor Snapshot: ${snapshotId}`
+      );
+      const data = localStorage.getItem(snapshotId);
+      if (data !== null) {
+        try {
+          return JSON.parse(data);
+        } catch (e) {
+          console.log(
+            `[Editor: ${editorId} - Page: ${pageIndex}] Invalid Snapshot: ${snapshotId}`
+          );
+          console.log(e);
+        }
+      }
+      return null;
+    },
+    [getSnapshotId]
+  );
 
-	const setEditorSnapshotToStorage = useCallback(
-		(editorId: string, pageIndex: number, snapshot: EditorSnapshot) => {
-			const snapshotId = getSnapshotId(editorId, pageIndex);
-			console.log(`[Editor: ${editorId} - Page: ${pageIndex}] Set Editor Snapshot: ${snapshotId}`);
-			localStorage.setItem(snapshotId, JSON.stringify(snapshot));
-		},
-		[getSnapshotId],
-	);
+  const setEditorSnapshotToStorage = useCallback(
+    (editorId: string, pageIndex: number, snapshot: EditorSnapshot) => {
+      const snapshotId = getSnapshotId(editorId, pageIndex);
+      console.log(
+        `[Editor: ${editorId} - Page: ${pageIndex}] Set Editor Snapshot: ${snapshotId}`
+      );
+      localStorage.setItem(snapshotId, JSON.stringify(snapshot));
+    },
+    [getSnapshotId]
+  );
 
-	const clearEditorSnapshotFromStorage = useCallback(
-		(editorId: string, pageIndex: number) => {
-			const snapshotId = getSnapshotId(editorId, pageIndex);
-			console.log(`[Editor: ${editorId} - Page: ${pageIndex}] Clear Editor Snapshot: ${snapshotId}`);
-			localStorage.removeItem(snapshotId);
-		},
-		[getSnapshotId],
-	);
+  const clearEditorSnapshotFromStorage = useCallback(
+    (editorId: string, pageIndex: number) => {
+      const snapshotId = getSnapshotId(editorId, pageIndex);
+      console.log(
+        `[Editor: ${editorId} - Page: ${pageIndex}] Clear Editor Snapshot: ${snapshotId}`
+      );
+      localStorage.removeItem(snapshotId);
+    },
+    [getSnapshotId]
+  );
 
-	const loadEmptySnapshot = useCallback(
-		(editorId: string) => {
-			const editor = getEditor(editorId);
-			if (editor === null) {
-				return;
-			}
-			console.log(`[Editor: ${editorId}] Load empty snapshot.`);
-			try {
-				editor.loadSnapshot(CleanPainterSnapshot as unknown as EditorSnapshot);
-			} catch {
-				console.log(`[Editor: ${editorId}] Unable to load empty snapshot.`);
-			}
-		},
-		[getEditor],
-	);
+  const loadEmptySnapshot = useCallback(
+    (editorId: string) => {
+      const editor = getEditor(editorId);
+      if (editor === null) {
+        return;
+      }
+      console.log(`[Editor: ${editorId}] Load empty snapshot.`);
+      try {
+        editor.loadSnapshot(CleanPainterSnapshot as unknown as EditorSnapshot);
+      } catch {
+        console.log(`[Editor: ${editorId}] Unable to load empty snapshot.`);
+      }
+    },
+    [getEditor]
+  );
 
-	const loadEditorSnapshot = useCallback(
-		(editorId: string, pageIndex: number) => {
-			const editor = getEditor(editorId);
-			if (editor === null) {
-				return;
-			}
-			const snapshotId = getSnapshotId(editorId, pageIndex);
-			console.log(`[Editor: ${editorId} - Page: ${pageIndex}] Load snapshot: ${snapshotId}`);
-			const snapShot = getEditorSnapshotFromStorage(editorId, pageIndex);
-			if (snapShot === null) {
-				console.log(`[Editor: ${editorId} - Page: ${pageIndex}] Snapshot not found: ${snapshotId}`);
-				loadEmptySnapshot(editorId);
-			} else {
-				try {
-					editor.loadSnapshot(snapShot);
-				} catch {
-					console.log(`[Editor: ${editorId} - Page: ${pageIndex}] Unable to load snapshot: ${snapshotId}`);
-					loadEmptySnapshot(editorId);
-				}
-			}
-		},
-		[getEditor, getSnapshotId, getEditorSnapshotFromStorage, loadEmptySnapshot],
-	);
+  const loadEditorSnapshot = useCallback(
+    (editorId: string, pageIndex: number) => {
+      const editor = getEditor(editorId);
+      if (editor === null) {
+        return;
+      }
+      const snapshotId = getSnapshotId(editorId, pageIndex);
+      console.log(
+        `[Editor: ${editorId} - Page: ${pageIndex}] Load snapshot: ${snapshotId}`
+      );
+      const snapShot = getEditorSnapshotFromStorage(editorId, pageIndex);
+      editor.store.mergeRemoteChanges(() => {
+        if (snapShot === null) {
+          console.log(
+            `[Editor: ${editorId} - Page: ${pageIndex}] Snapshot not found: ${snapshotId}`
+          );
+          loadEmptySnapshot(editorId);
+        } else {
+          try {
+            editor.loadSnapshot(snapShot);
+          } catch {
+            console.log(
+              `[Editor: ${editorId} - Page: ${pageIndex}] Unable to load snapshot: ${snapshotId}`
+            );
+            loadEmptySnapshot(editorId);
+          }
+        }
+      });
+    },
+    [getEditor, getSnapshotId, getEditorSnapshotFromStorage, loadEmptySnapshot]
+  );
 
-	const loadPageSnapshots = useCallback(
-		(pageIndex: number) => {
-			for (const editorId of Object.keys(editors.current)) {
-				loadEditorSnapshot(editorId, pageIndex);
-			}
-		},
-		[loadEditorSnapshot],
-	);
+  const loadPageSnapshots = useCallback(
+    (pageIndex: number) => {
+      for (const editorId of Object.keys(editors.current)) {
+        loadEditorSnapshot(editorId, pageIndex);
+      }
+    },
+    [loadEditorSnapshot]
+  );
 
-	const saveEditorSnapshot = useCallback(
-		(editorId: string, pageIndex: number) => {
-			const editor = getEditor(editorId);
-			if (editor === null) {
-				return;
-			}
-			const snapshotId = getSnapshotId(editorId, pageIndex);
-			console.log(`[Editor: ${editorId} - Page: ${pageIndex}] Save snapshot: ${snapshotId}`);
-			try {
-				editor.selectNone();
-				setEditorSnapshotToStorage(editorId, pageIndex, editor.getSnapshot());
-			} catch {
-				console.log(`[Editor: ${editorId} - Page: ${pageIndex}] Unable to save snapshot: ${snapshotId}`);
-			}
-		},
-		[getEditor, getSnapshotId, setEditorSnapshotToStorage],
-	);
+  const saveEditorSnapshot = useCallback(
+    (editorId: string, pageIndex: number) => {
+      const editor = getEditor(editorId);
+      if (editor === null) {
+        return;
+      }
+      const snapshotId = getSnapshotId(editorId, pageIndex);
+      console.log(
+        `[Editor: ${editorId} - Page: ${pageIndex}] Save snapshot: ${snapshotId}`
+      );
+      try {
+        editor.selectNone();
+        setEditorSnapshotToStorage(editorId, pageIndex, editor.getSnapshot());
+      } catch {
+        console.log(
+          `[Editor: ${editorId} - Page: ${pageIndex}] Unable to save snapshot: ${snapshotId}`
+        );
+      }
+    },
+    [getEditor, getSnapshotId, setEditorSnapshotToStorage]
+  );
 
-	const savePageSnapshots = useCallback(
-		(pageIndex: number) => {
-			for (const editorId of Object.keys(editors.current)) {
-				saveEditorSnapshot(editorId, pageIndex);
-			}
-		},
-		[saveEditorSnapshot],
-	);
+  const savePageSnapshots = useCallback(
+    (pageIndex: number) => {
+      for (const editorId of Object.keys(editors.current)) {
+        saveEditorSnapshot(editorId, pageIndex);
+      }
+    },
+    [saveEditorSnapshot]
+  );
 
-	const registerEditor = useCallback(
-		(editorId: string, editor: Editor) => {
-			editor.updateInstanceState({
-				isDebugMode: false,
-			});
-			editor.setCameraOptions({
-				isLocked: true,
-			});
-			if (editorId in editors.current) {
-				editors.current[editorId] = editor;
-			} else {
-				editors.current[editorId] = editor;
-				if (currentPageId.current !== null) {
-					loadEditorSnapshot(editorId, currentPageId.current);
-				}
-			}
-		},
-		[loadEditorSnapshot],
-	);
+  const registerEditor = useCallback(
+    (editorId: string, editor: Editor) => {
+      editor.updateInstanceState({
+        isDebugMode: false,
+      });
+      editor.setCameraOptions({
+        isLocked: true,
+      });
+      if (editorId in editors.current) {
+        editors.current[editorId] = editor;
+      } else {
+        editors.current[editorId] = editor;
+        if (currentPageId.current !== null) {
+          loadEditorSnapshot(editorId, currentPageId.current);
+        }
+      }
+    },
+    [loadEditorSnapshot]
+  );
 
-	const unregisterEditor = useCallback((editorId: string) => {
-		if (editorId in editors.current) {
-			delete editors.current[editorId];
-		}
-	}, []);
+  const unregisterEditor = useCallback((editorId: string) => {
+    if (editorId in editors.current) {
+      delete editors.current[editorId];
+    }
+  }, []);
 
-	useEffect(() => {
-		if (currentPageId.current !== pdfViewerController.getPageIndex()) {
-			if (currentPageId.current !== null) {
-				savePageSnapshots(currentPageId.current);
-			}
-			currentPageId.current = pdfViewerController.getPageIndex();
-			loadPageSnapshots(currentPageId.current);
-		}
-	}, [pdfViewerController, loadPageSnapshots, savePageSnapshots]);
+  useEffect(() => {
+    if (currentPageId.current !== pdfViewerController.getPageIndex()) {
+      if (currentPageId.current !== null) {
+        savePageSnapshots(currentPageId.current);
+      }
+      currentPageId.current = pdfViewerController.getPageIndex();
+      loadPageSnapshots(currentPageId.current);
+    }
+  }, [pdfViewerController, loadPageSnapshots, savePageSnapshots]);
 
-	useEffect(() => {
-		console.log("Update Camera");
-		const { width, height, baseX, baseY, scale } = pdfViewerController.getRenderOptions();
-		const pdfRenderScaleX = width / (pdfViewerController.getPage()?.originalWidth || 0) || 1;
-		const pdfRenderScaleY = height / (pdfViewerController.getPage()?.originalHeight || 0) || 1;
-		const pdfRenderScale = (pdfRenderScaleX + pdfRenderScaleY) / 2;
-		for (const editor of Object.values(editors.current)) {
-			editor.setCamera(
-				{
-					x: -baseX / pdfRenderScale,
-					y: -baseY / pdfRenderScale,
-					z: scale * pdfRenderScale,
-				},
-				{
-					force: true,
-				},
-			);
-		}
-	}, [pdfViewerController]);
+  useEffect(() => {
+    console.log("Update Camera");
+    const { width, height, baseX, baseY, scale } =
+      pdfViewerController.getRenderOptions();
+    const pdfRenderScaleX =
+      width / (pdfViewerController.getPage()?.originalWidth || 0) || 1;
+    const pdfRenderScaleY =
+      height / (pdfViewerController.getPage()?.originalHeight || 0) || 1;
+    const pdfRenderScale = (pdfRenderScaleX + pdfRenderScaleY) / 2;
+    for (const editor of Object.values(editors.current)) {
+      editor.setCamera(
+        {
+          x: -baseX / pdfRenderScale,
+          y: -baseY / pdfRenderScale,
+          z: scale * pdfRenderScale,
+        },
+        {
+          force: true,
+        }
+      );
+    }
+  }, [pdfViewerController]);
 
-	const getEditorSnapshot = useCallback(
-		(editorId: string, pageIndex: number): EditorSnapshot | null => {
-			saveEditorSnapshot(editorId, pageIndex);
-			return getEditorSnapshotFromStorage(editorId, pageIndex);
-		},
-		[saveEditorSnapshot, getEditorSnapshotFromStorage],
-	);
+  const getEditorSnapshot = useCallback(
+    (editorId: string, pageIndex: number): EditorSnapshot | null => {
+      saveEditorSnapshot(editorId, pageIndex);
+      return getEditorSnapshotFromStorage(editorId, pageIndex);
+    },
+    [saveEditorSnapshot, getEditorSnapshotFromStorage]
+  );
 
-	const setEditorSnapshot = useCallback(
-		(editorId: string, pageIndex: number, snapshot: EditorSnapshot) => {
-			setEditorSnapshotToStorage(editorId, pageIndex, snapshot);
-			loadEditorSnapshot(editorId, pageIndex);
-		},
-		[loadEditorSnapshot, setEditorSnapshotToStorage],
-	);
+  const setEditorSnapshot = useCallback(
+    (editorId: string, pageIndex: number, snapshot: EditorSnapshot) => {
+      setEditorSnapshotToStorage(editorId, pageIndex, snapshot);
+      loadEditorSnapshot(editorId, pageIndex);
+    },
+    [loadEditorSnapshot, setEditorSnapshotToStorage]
+  );
 
-	const clearEditorSnapshot = useCallback(
-		(editorId: string, pageIndex: number) => {
-			clearEditorSnapshotFromStorage(editorId, pageIndex);
-			loadEditorSnapshot(editorId, pageIndex);
-		},
-		[loadEditorSnapshot, clearEditorSnapshotFromStorage],
-	);
+  const clearEditorSnapshot = useCallback(
+    (editorId: string, pageIndex: number) => {
+      clearEditorSnapshotFromStorage(editorId, pageIndex);
+      loadEditorSnapshot(editorId, pageIndex);
+    },
+    [loadEditorSnapshot, clearEditorSnapshotFromStorage]
+  );
 
-	const pdfPainterController: PDFPainterController = useMemo(() => {
-		return {
-			...pdfViewerController,
-			getPaintMode: () => {
-				return paintMode;
-			},
-			setPaintMode: (paintMode: PaintMode) => {
-				setPaintMode(paintMode);
-			},
-			registerEditor: registerEditor,
-			unregisterEditor: unregisterEditor,
-			getEditor: getEditor,
-			getEditorSnapshot: getEditorSnapshot,
-			setEditorSnapshot: setEditorSnapshot,
-			clearEditorSnapshot: clearEditorSnapshot,
-		};
-	}, [pdfViewerController, paintMode, registerEditor, unregisterEditor, getEditor, getEditorSnapshot, setEditorSnapshot, clearEditorSnapshot]);
+  const pdfPainterController: PDFPainterController = useMemo(() => {
+    return {
+      ...pdfViewerController,
+      getPaintMode: () => {
+        return paintMode;
+      },
+      setPaintMode: (paintMode: PaintMode) => {
+        setPaintMode(paintMode);
+      },
+      registerEditor: registerEditor,
+      unregisterEditor: unregisterEditor,
+      getEditor: getEditor,
+      getEditorSnapshot: getEditorSnapshot,
+      setEditorSnapshot: setEditorSnapshot,
+      clearEditorSnapshot: clearEditorSnapshot,
+    };
+  }, [
+    pdfViewerController,
+    paintMode,
+    registerEditor,
+    unregisterEditor,
+    getEditor,
+    getEditorSnapshot,
+    setEditorSnapshot,
+    clearEditorSnapshot,
+  ]);
 
-	return {
-		pdfPainterController: pdfPainterController,
-		onPdfDocumentChange: onPdfDocumentChange,
-		onPdfPageChange: onPdfPageChange,
-		onPdfItemClick: onPdfItemClick,
-		onPdfMouseMoveEvent: onPdfMouseMoveEvent,
-		onPdfWheelEvent: onPdfWheelEvent,
-		externalAssetStore: externalAssetStore,
-	};
+  return {
+    pdfPainterController: pdfPainterController,
+    onPdfDocumentChange: onPdfDocumentChange,
+    onPdfPageChange: onPdfPageChange,
+    onPdfItemClick: onPdfItemClick,
+    onPdfMouseMoveEvent: onPdfMouseMoveEvent,
+    onPdfWheelEvent: onPdfWheelEvent,
+    externalAssetStore: externalAssetStore,
+  };
 };

--- a/packages/front-end/app/view/[sessionId]/_hooks/useReceiveDrawCache.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useReceiveDrawCache.ts
@@ -47,25 +47,37 @@ export const useReceiveDrawCache = (editor: Editor | null) => {
       if (pageDrawMap === undefined || editor === null) return;
       // editor관련 코드가 pageIndex를 순회하진 않음
       editor.store.put(
-        Array.from(pageDrawMap.values()).map((value) => {
-          const record = value as { type: string | undefined } & typeof value;
-          if (record.type === undefined) {
-            const recordFromEditor = editor.store.get(value.id);
-            console.warn("WEIRD RECORD! but don't worry. It will works well...maybe", {
-              record: integralRecord(recordFromEditor, value),
-            });
-            return integralRecord(recordFromEditor, value);
-          } else {
-            return record;
-          }
-        })
+        Array.from(pageDrawMap.values())
+          .map((value) => {
+            const record = value as { type: string | undefined } & typeof value;
+            if (record.type === undefined) {
+              const recordFromEditor = editor.store.get(value.id);
+              if (recordFromEditor !== undefined) {
+                console.warn(
+                  "WEIRD RECORD! but don't worry. It will works well...maybe",
+                  {
+                    record: integralRecord(recordFromEditor, value),
+                  }
+                );
+                return integralRecord(recordFromEditor, value);
+              } else {
+                console.error(
+                  "WEIRD RECORD! I can't find original from editor ID:",
+                  value.id
+                );
+                return null;
+              }
+            } else {
+              return record;
+            }
+          })
+          .filter((value) => value !== null)
       );
       drawCacheRef.current.delete(pageIndex);
     },
     [editor]
   );
 
-  
   return {
     removeDrawCache,
     addDrawCache,


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 버그 수정

## ❗️ 관련 이슈 [#]
close #391 
## 📄 개요
- 유저와 상호작용한 데이터만 소켓통신으로 보내야함
- 페이지를 이동하거나 HTTP req등과 같이 코드를 통한 tldraw 필기 데이터 통신은 많은 낭비를 초래해 고침 
## 🔁 변경 사항
- [store.mergeRemoteChanges] (https://tldraw.dev/reference/store/Store#mergeRemoteChanges) 사용
- 해당 함수 내부의 store 조작 코드는 store.onListen에 잡히지 않음
- 왜냐하면 store.onListen의 filter는 현재 source:"user"기 때문임
- 각 history record는 내부적으로 mergeRemoteChange (이름이 이거랑 비슷)이란 boolean값이 붙어있고 source:"user"은 해당 불린값이 true라면 onListen에 넘기지 않음

## 📸 동작 화면 스크린샷

## 👀 기타 논의 사항