### PR TITLE
395 socket room

### DIFF
--- a/packages/socket-server/src/utils/bi-map.class.spec.ts
+++ b/packages/socket-server/src/utils/bi-map.class.spec.ts
@@ -1,0 +1,52 @@
+import { BiMap } from './bi-map.class';
+
+describe('BiMap', () => {
+  let biMap: BiMap<string, number>;
+
+  beforeEach(() => {
+    biMap = new BiMap<string, number>();
+  });
+
+  it('should be accessible from both directions once set.', () => {
+    biMap.set('user1', 1);
+    expect(biMap.getByLeft('user1')).toBe(1);
+    expect(biMap.getByRight(1)).toBe('user1');
+  });
+
+  it('should be maintained one-to-one matching after update.', () => {
+    biMap.set('user1', 1);
+    biMap.set('user1', 2);
+    expect(biMap.getByLeft('user1')).toBe(2);
+    expect(biMap.getByRight(2)).toBe('user1');
+    expect(biMap.getByRight(1)).toBe(undefined);
+  });
+
+  it('should overwrite the existing value for a key', () => {
+    biMap.set('user1', 1);
+    biMap.set('user1', 2);
+    expect(biMap.getValue('user1')).toBe(2);
+    expect(biMap.getKey(2)).toBe('user1');
+    expect(biMap.getKey(1)).toBeUndefined();
+  });
+
+  it('should overwrite the existing key for a value', () => {
+    biMap.set('user1', 1);
+    biMap.set('user2', 1); // Overwriting value 1
+    expect(biMap.getValue('user1')).toBeUndefined();
+    expect(biMap.getKey(1)).toBe('user2');
+  });
+
+  it('should delete by key', () => {
+    biMap.set('user1', 1);
+    biMap.deleteByKey('user1');
+    expect(biMap.getValue('user1')).toBeUndefined();
+    expect(biMap.getKey(1)).toBeUndefined();
+  });
+
+  it('should delete by value', () => {
+    biMap.set('user1', 1);
+    biMap.deleteByValue(1);
+    expect(biMap.getValue('user1')).toBeUndefined();
+    expect(biMap.getKey(1)).toBeUndefined();
+  });
+});

--- a/packages/socket-server/src/utils/bi-map.class.spec.ts
+++ b/packages/socket-server/src/utils/bi-map.class.spec.ts
@@ -1,5 +1,49 @@
 import { BiMap } from './bi-map.class';
 
+describe('BiMap', () => {
+  let biMap: BiMap<string, number>;
+
+  beforeEach(() => {
+    biMap = new BiMap<string, number>();
+  });
+
+  it('should be accessible from both sides after set.', () => {
+    biMap.set('user1', 1);
+    expect(biMap.getByLeft('user1')).toBe(1);
+    expect(biMap.getByRight(1)).toBe('user1');
+  });
+
+  it('should be accessible from both sides after update the right.', () => {
+    biMap.set('user1', 1);
+    biMap.set('user1', 2);
+    expect(biMap.getByLeft('user1')).toBe(2);
+    expect(biMap.getByRight(2)).toBe('user1');
+    expect(biMap.hasByRight(1)).toBe(true);
+  });
+
+  it('should be accessible from both sides after update the left.', () => {
+    biMap.set('user1', 1);
+    biMap.set('user2', 1);
+    expect(biMap.getByLeft('user2')).toBe(1);
+    expect(biMap.getByRight(1)).toBe('user2');
+    expect(biMap.hasByLeft('user1')).toBe(true);
+  });
+
+  it('should be deleted by left', () => {
+    biMap.set('user1', 1);
+    biMap.deleteByLeft('user1');
+    expect(biMap.hasByLeft('user1')).toBe(false);
+    expect(biMap.hasByRight(1)).toBe(true);
+  });
+
+  it('should be deleted by right', () => {
+    biMap.set('user1', 1);
+    biMap.deleteByRight(1);
+    expect(biMap.hasByLeft('user1')).toBe(true);
+    expect(biMap.hasByRight(1)).toBe(false);
+  });
+});
+
 describe('OneToOne BiMap', () => {
   let biMap: BiMap<string, number>;
 

--- a/packages/socket-server/src/utils/bi-map.class.spec.ts
+++ b/packages/socket-server/src/utils/bi-map.class.spec.ts
@@ -7,46 +7,39 @@ describe('BiMap', () => {
     biMap = new BiMap<string, number>();
   });
 
-  it('should be accessible from both directions once set.', () => {
+  it('should be accessible from both sides after set.', () => {
     biMap.set('user1', 1);
     expect(biMap.getByLeft('user1')).toBe(1);
     expect(biMap.getByRight(1)).toBe('user1');
   });
 
-  it('should be maintained one-to-one matching after update.', () => {
+  it('should be maintained one-to-one matching after update the right.', () => {
     biMap.set('user1', 1);
     biMap.set('user1', 2);
     expect(biMap.getByLeft('user1')).toBe(2);
     expect(biMap.getByRight(2)).toBe('user1');
-    expect(biMap.getByRight(1)).toBe(undefined);
+    expect(biMap.hasByRight(1)).toBe(false);
   });
 
-  it('should overwrite the existing value for a key', () => {
+  it('should be maintained one-to-one matching after update the left.', () => {
     biMap.set('user1', 1);
-    biMap.set('user1', 2);
-    expect(biMap.getValue('user1')).toBe(2);
-    expect(biMap.getKey(2)).toBe('user1');
-    expect(biMap.getKey(1)).toBeUndefined();
+    biMap.set('user2', 1);
+    expect(biMap.getByLeft('user2')).toBe(1);
+    expect(biMap.getByRight(1)).toBe('user2');
+    expect(biMap.hasByLeft('user1')).toBe(false);
   });
 
-  it('should overwrite the existing key for a value', () => {
+  it('should be deleted from both sides by left', () => {
     biMap.set('user1', 1);
-    biMap.set('user2', 1); // Overwriting value 1
-    expect(biMap.getValue('user1')).toBeUndefined();
-    expect(biMap.getKey(1)).toBe('user2');
+    biMap.deleteByLeft('user1');
+    expect(biMap.hasByLeft('user1')).toBe(false);
+    expect(biMap.hasByRight(1)).toBe(false);
   });
 
-  it('should delete by key', () => {
+  it('should be deleted from both sides by right', () => {
     biMap.set('user1', 1);
-    biMap.deleteByKey('user1');
-    expect(biMap.getValue('user1')).toBeUndefined();
-    expect(biMap.getKey(1)).toBeUndefined();
-  });
-
-  it('should delete by value', () => {
-    biMap.set('user1', 1);
-    biMap.deleteByValue(1);
-    expect(biMap.getValue('user1')).toBeUndefined();
-    expect(biMap.getKey(1)).toBeUndefined();
+    biMap.deleteByRight(1);
+    expect(biMap.hasByLeft('user1')).toBe(false);
+    expect(biMap.hasByRight(1)).toBe(false);
   });
 });

--- a/packages/socket-server/src/utils/bi-map.class.spec.ts
+++ b/packages/socket-server/src/utils/bi-map.class.spec.ts
@@ -1,10 +1,10 @@
 import { BiMap } from './bi-map.class';
 
-describe('BiMap', () => {
+describe('OneToOne BiMap', () => {
   let biMap: BiMap<string, number>;
 
   beforeEach(() => {
-    biMap = new BiMap<string, number>();
+    biMap = new BiMap<string, number>({ isOneToOne: true });
   });
 
   it('should be accessible from both sides after set.', () => {

--- a/packages/socket-server/src/utils/bi-map.class.ts
+++ b/packages/socket-server/src/utils/bi-map.class.ts
@@ -1,0 +1,37 @@
+export class BiMap<L = any, R = any> {
+  private leftToRight: Map<L, R>;
+  private rightToLeft: Map<R, L>;
+  constructor() {
+    this.leftToRight = new Map<L, R>();
+    this.rightToLeft = new Map<R, L>();
+  }
+
+  set(left: L, right: R): void {
+    const prevRight = this.getByLeft(left);
+    const prevLeft = this.getByRight(right);
+    if (prevRight !== undefined) {
+      this.deleteByRight(prevRight);
+    }
+    if (prevLeft !== undefined) {
+      this.deleteByLeft(prevLeft);
+    }
+    this.leftToRight.set(left, right);
+    this.rightToLeft.set(right, left);
+  }
+  getByLeft(left: L): R | undefined {
+    return this.leftToRight.get(left);
+  }
+  getByRight(right: R): L | undefined {
+    return this.rightToLeft.get(right);
+  }
+  deleteByLeft(left: L): void {
+    const right = this.getByLeft(left);
+    this.leftToRight.delete(left);
+    this.rightToLeft.delete(right);
+  }
+  deleteByRight(right: R): void {
+    const left = this.getByRight(right);
+    this.rightToLeft.delete(right);
+    this.leftToRight.delete(left);
+  }
+}

--- a/packages/socket-server/src/utils/bi-map.class.ts
+++ b/packages/socket-server/src/utils/bi-map.class.ts
@@ -34,4 +34,11 @@ export class BiMap<L = any, R = any> {
     this.rightToLeft.delete(right);
     this.leftToRight.delete(left);
   }
+
+  hasByLeft(left: L): boolean {
+    return this.leftToRight.has(left);
+  }
+  hasByRight(right: R): boolean {
+    return this.rightToLeft.has(right);
+  }
 }

--- a/packages/socket-server/src/utils/bi-map.class.ts
+++ b/packages/socket-server/src/utils/bi-map.class.ts
@@ -17,6 +17,12 @@ export class BiMap<L = any, R = any> {
     this.leftToRight.set(left, right);
     this.rightToLeft.set(right, left);
   }
+  getLeftToRight(): Map<L, R> {
+    return this.leftToRight;
+  }
+  getRightToLeft(): Map<R, L> {
+    return this.rightToLeft;
+  }
   getByLeft(left: L): R | undefined {
     return this.leftToRight.get(left);
   }

--- a/packages/socket-server/src/utils/bi-map.class.ts
+++ b/packages/socket-server/src/utils/bi-map.class.ts
@@ -1,18 +1,22 @@
 export class BiMap<L = any, R = any> {
   private leftToRight: Map<L, R>;
   private rightToLeft: Map<R, L>;
-  constructor() {
+  private isOneToOne: boolean;
+  constructor(opts?: { isOneToOne?: boolean }) {
     this.leftToRight = new Map<L, R>();
     this.rightToLeft = new Map<R, L>();
+    this.isOneToOne = !!opts?.isOneToOne;
   }
   set(left: L, right: R): void {
-    const prevRight = this.getByLeft(left);
-    const prevLeft = this.getByRight(right);
-    if (prevRight !== undefined) {
-      this.deleteByRight(prevRight);
-    }
-    if (prevLeft !== undefined) {
-      this.deleteByLeft(prevLeft);
+    if (this.isOneToOne) {
+      const prevRight = this.getByLeft(left);
+      const prevLeft = this.getByRight(right);
+      if (prevRight !== undefined) {
+        this.deleteByRight(prevRight);
+      }
+      if (prevLeft !== undefined) {
+        this.deleteByLeft(prevLeft);
+      }
     }
     this.leftToRight.set(left, right);
     this.rightToLeft.set(right, left);
@@ -31,13 +35,17 @@ export class BiMap<L = any, R = any> {
   }
   deleteByLeft(left: L): void {
     const right = this.getByLeft(left);
-    this.leftToRight.delete(left);
-    this.rightToLeft.delete(right);
+    if (this.isOneToOne) {
+      this.leftToRight.delete(left);
+      this.rightToLeft.delete(right);
+    }
   }
   deleteByRight(right: R): void {
     const left = this.getByRight(right);
-    this.rightToLeft.delete(right);
-    this.leftToRight.delete(left);
+    if (this.isOneToOne) {
+      this.rightToLeft.delete(right);
+      this.leftToRight.delete(left);
+    }
   }
   hasByLeft(left: L): boolean {
     return this.leftToRight.has(left);

--- a/packages/socket-server/src/utils/bi-map.class.ts
+++ b/packages/socket-server/src/utils/bi-map.class.ts
@@ -5,7 +5,6 @@ export class BiMap<L = any, R = any> {
     this.leftToRight = new Map<L, R>();
     this.rightToLeft = new Map<R, L>();
   }
-
   set(left: L, right: R): void {
     const prevRight = this.getByLeft(left);
     const prevLeft = this.getByRight(right);
@@ -34,11 +33,20 @@ export class BiMap<L = any, R = any> {
     this.rightToLeft.delete(right);
     this.leftToRight.delete(left);
   }
-
   hasByLeft(left: L): boolean {
     return this.leftToRight.has(left);
   }
   hasByRight(right: R): boolean {
     return this.rightToLeft.has(right);
+  }
+  clear(): void {
+    this.leftToRight.clear();
+    this.rightToLeft.clear();
+  }
+  entries(): IterableIterator<[L, R]> {
+    return this.leftToRight.entries();
+  }
+  forEach(callbackfn: (value: R, key: L, map: Map<L, R>) => void): void {
+    this.leftToRight.forEach(callbackfn);
   }
 }

--- a/packages/socket-server/src/utils/bi-map.class.ts
+++ b/packages/socket-server/src/utils/bi-map.class.ts
@@ -35,15 +35,15 @@ export class BiMap<L = any, R = any> {
   }
   deleteByLeft(left: L): void {
     const right = this.getByLeft(left);
+    this.leftToRight.delete(left);
     if (this.isOneToOne) {
-      this.leftToRight.delete(left);
       this.rightToLeft.delete(right);
     }
   }
   deleteByRight(right: R): void {
     const left = this.getByRight(right);
+    this.rightToLeft.delete(right);
     if (this.isOneToOne) {
-      this.rightToLeft.delete(right);
       this.leftToRight.delete(left);
     }
   }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가

## ❗️ 관련 이슈 [#]
#395 (Don't close it yet)
## 📄 개요
- client.id와 userId를 1대1로 편하게 관리해줄 수 있게 해주는 자료구조
- 두개의 map을 사용함
  - has(있는지 여부)
  - set(설정)
  - get(가져오기, 없으면 Undefined)
  - delete(양쪽 다 지우기)
## 🔁 변경 사항
- 최대한 기존 Map과 비슷하지만 명확한 사용감을 주도록 했음
1. set할시 새로운 값이면 추가된다.
2. set할시 기존 값이 있다면 연결을 끊고 새로운 1대1매칭을 만든다.
3. delete할시 1대1 매칭 연결이 사라진다.
- 이를 구현했고 테스트코드 작성(통과함)
## 📸 동작 화면 스크린샷

## 👀 기타 논의 사항
- 적용할지는 @1000chw 와 논의
- 이걸 이용하면 방 관리는 userId 또는 client.id 둘중 하나로만 관리 가능
## ⏰ 마감기한 회고
- 별로 어려운 PR은 아니라 예상한대로 1시간 정도? 끝남
- 시간이 어느정도 남아서 테스트 코드도 작성