### PR TITLE
395 one to many

### DIFF
--- a/packages/socket-server/src/socket/utils/one-to-many-map.class.spec.ts
+++ b/packages/socket-server/src/socket/utils/one-to-many-map.class.spec.ts
@@ -6,5 +6,40 @@ describe('OneToManyMap', () => {
   beforeEach(() => {
     oneToManyMap = new OneToManyMap<string, number>();
   });
-  
+  it('should be accessible after set.', () => {
+    oneToManyMap.set('room1', 1);
+    oneToManyMap.set('room1', 2);
+    expect(oneToManyMap.hasOne('room1')).toBe(true);
+    expect(oneToManyMap.getByMany(1)).toBe('room1');
+    expect(oneToManyMap.getByMany(2)).toBe('room1');
+  });
+  it('should be maintained one to many relation.', () => {
+    oneToManyMap.set('room1', 1);
+    oneToManyMap.set('room1', 2);
+    oneToManyMap.set('room2', 1);
+    expect(oneToManyMap.getByMany(1)).toBe('room2');
+    expect(oneToManyMap.getByOne('room2').has(1));
+    expect(oneToManyMap.getByOne('room1').has(1)).toBe(false);
+  });
+  it('should clean up memory when set causes empty state.', () => {
+    oneToManyMap.set('room1', 1);
+    oneToManyMap.set('room2', 1);
+    expect(oneToManyMap.getByMany(1)).toBe('room2');
+    expect(oneToManyMap.getByOne('room2').has(1));
+    expect(oneToManyMap.hasOne('room1')).toBe(false);
+  });
+  it('should clean up memory when delete causes empty state.', () => {
+    oneToManyMap.set('room1', 1);
+    oneToManyMap.deleteByMany(1);
+    expect(oneToManyMap.hasMany(1)).toBe(false);
+    expect(oneToManyMap.hasOne('room1')).toBe(false);
+  });
+  it('should delete many when its one is deleted.', () => {
+    oneToManyMap.set('room1', 1);
+    oneToManyMap.set('room1', 2);
+    oneToManyMap.deleteByOne('room1');
+    expect(oneToManyMap.hasOne('room1')).toBe(false);
+    expect(oneToManyMap.hasMany(1)).toBe(false);
+    expect(oneToManyMap.hasMany(2)).toBe(false);
+  });
 });

--- a/packages/socket-server/src/socket/utils/one-to-many-map.class.spec.ts
+++ b/packages/socket-server/src/socket/utils/one-to-many-map.class.spec.ts
@@ -1,0 +1,10 @@
+import { OneToManyMap } from './one-to-many-map.class';
+
+describe('OneToManyMap', () => {
+  let oneToManyMap: OneToManyMap<string, number>;
+
+  beforeEach(() => {
+    oneToManyMap = new OneToManyMap<string, number>();
+  });
+  
+});

--- a/packages/socket-server/src/socket/utils/one-to-many-map.class.ts
+++ b/packages/socket-server/src/socket/utils/one-to-many-map.class.ts
@@ -5,9 +5,15 @@ export class OneToManyMap<O = any, M = any> {
     this.oneToMany = new Map<O, Set<M>>();
     this.manyToOne = new Map<M, O>();
   }
+  private cleanOneMemoryIfEmpty(o: O) {
+    if (this.oneToMany.get(o).size === 0) {
+      this.deleteByOne(o);
+    }
+  }
   private disconnectByMany(m: M) {
     const o = this.manyToOne.get(m);
     this.oneToMany.get(o).delete(m);
+    this.cleanOneMemoryIfEmpty(o);
   }
   set(o: O, m: M) {
     if (this.manyToOne.has(m)) {
@@ -33,14 +39,21 @@ export class OneToManyMap<O = any, M = any> {
   }
   deleteByMany(m: M) {
     const o = this.manyToOne.get(m);
-    this.oneToMany.get(o).delete(m);
     this.manyToOne.delete(m);
+    this.oneToMany.get(o).delete(m);
+    this.cleanOneMemoryIfEmpty(o);
   }
   deleteByOne(o: O) {
     this.oneToMany.get(o).forEach((m) => {
       this.manyToOne.delete(m);
     });
     this.oneToMany.delete(o);
+  }
+  hasOne(o: O) {
+    return this.oneToMany.has(o);
+  }
+  hasMany(m: M) {
+    return this.manyToOne.has(m);
   }
   clear() {
     this.oneToMany.clear();

--- a/packages/socket-server/src/socket/utils/one-to-many-map.class.ts
+++ b/packages/socket-server/src/socket/utils/one-to-many-map.class.ts
@@ -1,0 +1,49 @@
+export class OneToManyMap<O = any, M = any> {
+  private oneToMany: Map<O, Set<M>>;
+  private manyToOne: Map<M, O>;
+  constructor() {
+    this.oneToMany = new Map<O, Set<M>>();
+    this.manyToOne = new Map<M, O>();
+  }
+  private disconnectByMany(m: M) {
+    const o = this.manyToOne.get(m);
+    this.oneToMany.get(o).delete(m);
+  }
+  set(o: O, m: M) {
+    if (this.manyToOne.has(m)) {
+      this.disconnectByMany(m);
+    }
+    if (!this.oneToMany.has(o)) {
+      this.oneToMany.set(o, new Set<M>());
+    }
+    this.oneToMany.get(o).add(m);
+    this.manyToOne.set(m, o);
+  }
+  getByOne(o: O) {
+    return this.oneToMany.get(o);
+  }
+  getByMany(m: M) {
+    return this.manyToOne.get(m);
+  }
+  getOneToMany() {
+    return this.oneToMany;
+  }
+  getManyToIne() {
+    return this.manyToOne;
+  }
+  deleteByMany(m: M) {
+    const o = this.manyToOne.get(m);
+    this.oneToMany.get(o).delete(m);
+    this.manyToOne.delete(m);
+  }
+  deleteByOne(o: O) {
+    this.oneToMany.get(o).forEach((m) => {
+      this.manyToOne.delete(m);
+    });
+    this.oneToMany.delete(o);
+  }
+  clear() {
+    this.oneToMany.clear();
+    this.manyToOne.clear();
+  }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가

## ❗️ 관련 이슈 [#]
#395 (Don't close yet)
## 📄 개요
- 페이지 번호 같은거 관리할때 변할 1:N 관리 자료구조
- 기본적으로 1(one): O, N(many):set(M) 타입으로 관리
- 삽입 및 수정 및 삭제시 1:N 유지 
- 테스트 통과함
## 🔁 변경 사항
- 대충 쓰고 TDD로 개발하려했는데 대충 테스트 다 통과하니 좋았쓰
- 기존 map,set과 비슷하나 구분이 명확한 메서드명을 고민했습니다. (has set get...)
- set은 추가 및 수정 모두 호출하도록해 편의성을 높임(안정성이 약간 떨어지나 문제되지 않는다고 판단)
- 유닛테스트는 ㄱ본 로직보단 1:N을 유지하기위한 추가적인 로직을 테스트

## 📸 동작 화면 스크린샷

## 👀 기타 논의 사항
- 1:1 및 1:N 맵 자료구조 사용은 추후문서화, 일단 나한테 연락바람
## ⏰ 마감기한 회고
-갑자기 만든거라... 마감기한을 정하진 않음 하지만 1:1을 이미 만들어놓아서 매우 빠르게 제작한 것 같음