### PR TITLE
407 page info

### DIFF
--- a/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
@@ -10,8 +10,9 @@ import {
 import { ViewerPropType } from "../_types/ViewerType";
 
 export default function HostViewer(props: ViewerPropType) {
-  const { fileList, userId, sessionId } = props;
+  const { fileList, sessionId } = props;
   const pdfDocument = fileList[0];
+  const fileId = fileList[0].fileId;
   const pdfPainterControllerHook = usePDFPainterController({
     painterId: `${sessionId}_${pdfDocument.fileId}`,
   });
@@ -21,6 +22,7 @@ export default function HostViewer(props: ViewerPropType) {
   });
   useHostSocket(
     sessionId,
+    fileId,
     pdfPainterHostInstanceControllerHook.pdfPainterInstanceController,
     pdfPainterControllerHook.pdfPainterController
   );

--- a/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
@@ -13,13 +13,10 @@ import {
 } from "@/PaintPDF/components";
 import { ViewerPropType } from "../_types/ViewerType";
 
-interface SessionReturnType extends Session {
-  fileList: File[];
-}
-
 export default function ParticipantViewer(props: ViewerPropType) {
-  const { sessionName, fileList, userId, sessionId } = props;
+  const { fileList, sessionId } = props;
   const pdfDocument = fileList[0];
+  const fileId = fileList[0].fileId;
   const joinQuery = useQuery<AxiosResponse<any>>({
     queryKey: ["user", "session", sessionId, "join"],
     queryFn: async () => {
@@ -40,6 +37,7 @@ export default function ParticipantViewer(props: ViewerPropType) {
     });
   useParticipantSocket(
     sessionId,
+    fileId,
     pdfPainterHostInstanceControllerHook.pdfPainterInstanceController,
     pdfPainterControllerHook.pdfPainterController
   );

--- a/packages/front-end/app/view/[sessionId]/_hooks/useBatchSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useBatchSocket.ts
@@ -30,10 +30,12 @@ export const useBatchSocket = ({
   socket,
   roomId,
   pageIndex,
+  fileId,
 }: {
   socket: Socket | null;
   roomId: number | string;
   pageIndex: number;
+  fileId: number;
 }) => {
   const queueRef = useRef<{
     [key in RecordId<any>]: ElementType[];
@@ -149,7 +151,8 @@ export const useBatchSocket = ({
       const dataFormat = processBatchQueue();
       const messageBody = {
         index: pageIndex,
-        roomId: roomId,
+        roomId,
+        fileId,
       };
       if (dataFormat.added.length > 0) {
         socket.emit("sendAddedDraw", {
@@ -174,6 +177,6 @@ export const useBatchSocket = ({
     return () => {
       clearInterval(intervalId);
     };
-  }, [pageIndex, processBatchQueue, roomId, socket]);
+  }, [fileId, pageIndex, processBatchQueue, roomId, socket]);
   return { queueRef, pushChanges };
 };

--- a/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
@@ -15,23 +15,24 @@ export const useHostSocket = (
 ) => {
   const [socket] = useAtom(socketAtom);
   const pageIndex = pdfPainterController.getPageIndex();
-  const { pushChanges } = useBatchSocket({ socket, roomId, pageIndex,fileId });
+  const { pushChanges } = useBatchSocket({ socket, roomId, pageIndex, fileId });
 
   const editor = pdfPainterInstanceController.getEditor();
 
   useEffect(() => {
     if (socket === null) return;
+    console.log("connect UseEffect",socket)
     socket.on("connect", () => {
-      console.log("Connected to WebSocket server");
-      socket.emit("createRoom", { roomId, fileId });
+      console.error("Connected to WebSocket server");
+      socket.emit("createRoom", { roomId, fileIds: [fileId] });
     });
     socket.on("userList", (userList: any) => {
       console.log({ userList });
     });
-    return () => {
-      socket.off("connect");
-      socket.off("userList");
-    };
+    // return () => {
+    //   socket.off("connect");
+    //   socket.off("userList");
+    // };
   }, [fileId, roomId, socket]);
 
   useEffect(() => {

--- a/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
@@ -30,6 +30,9 @@ export const useHostSocket = (
         socket.emit("createRoom", { roomId, fileIds: [fileId] });
       });
     }
+    socket.on("reconnect",()=>{
+      console.error("re")
+    })
     socket.on("userList", (userList: any) => {
       console.log({ userList });
     });
@@ -38,6 +41,17 @@ export const useHostSocket = (
       socket.off("userList");
     };
   }, [fileId, roomId, socket]);
+
+  useEffect(()=>{
+    if (socket === null) return;
+    socket.on("getPageNumber",({roomPageViewCount})=>{
+      console.log(roomPageViewCount)
+    })
+    return () => {
+      socket.off("getPageNumber");
+    }
+  },[socket])
+  
 
   useEffect(() => {
     if (socket === null) return;

--- a/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
@@ -1,11 +1,8 @@
-import { useEffect, useState } from "react";
-import { io, Socket } from "socket.io-client";
+import { useEffect } from "react";
 import { useBatchSocket } from "./useBatchSocket";
 import {
   PDFPainterController,
-  PDFPainterControllerHook,
   PDFPainterInstanceController,
-  PDFPainterInstanceControllerHook,
 } from "@/PaintPDF/components";
 import { socketAtom } from "@/client/socketAtom";
 import { useAtom } from "jotai";
@@ -23,22 +20,29 @@ export const useHostSocket = (
 
   useEffect(() => {
     if (socket === null) return;
-    if (editor === null) return;
-    const { store } = editor;
-
     socket.on("connect", () => {
       console.log("Connected to WebSocket server");
-      socket.off("createRoom")
       socket.emit("createRoom", { roomId: roomId });
     });
     socket.on("userList", (userList: any) => {
       console.log({ userList });
     });
+    return () => {
+      socket.off("connect");
+      socket.off("userList");
+    };
+  }, [roomId, socket]);
+
+  useEffect(() => {
+    if (socket === null) return;
+    if (editor === null) return;
+    const { store } = editor;
+
     store.listen(
       ({ changes }) => {
         pushChanges(changes);
       },
       { source: "user", scope: "document" }
     );
-  }, [editor, pushChanges, roomId, socket]);
+  }, [editor, pushChanges, socket]);
 };

--- a/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
@@ -21,18 +21,22 @@ export const useHostSocket = (
 
   useEffect(() => {
     if (socket === null) return;
-    console.log("connect UseEffect",socket)
-    socket.on("connect", () => {
+    if (socket.connected) {
       console.error("Connected to WebSocket server");
       socket.emit("createRoom", { roomId, fileIds: [fileId] });
-    });
+    } else {
+      socket.on("connect", () => {
+        console.error("Connected to WebSocket server");
+        socket.emit("createRoom", { roomId, fileIds: [fileId] });
+      });
+    }
     socket.on("userList", (userList: any) => {
       console.log({ userList });
     });
-    // return () => {
-    //   socket.off("connect");
-    //   socket.off("userList");
-    // };
+    return () => {
+      socket.off("connect");
+      socket.off("userList");
+    };
   }, [fileId, roomId, socket]);
 
   useEffect(() => {

--- a/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
@@ -44,8 +44,8 @@ export const useHostSocket = (
 
   useEffect(()=>{
     if (socket === null) return;
-    socket.on("getPageNumber",({roomPageViewCount})=>{
-      console.log(roomPageViewCount)
+    socket.on("getPageNumber",(data)=>{
+      console.log(data)
     })
     return () => {
       socket.off("getPageNumber");

--- a/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
@@ -9,12 +9,13 @@ import { useAtom } from "jotai";
 
 export const useHostSocket = (
   roomId: number | string,
+  fileId: number,
   pdfPainterInstanceController: PDFPainterInstanceController,
   pdfPainterController: PDFPainterController
 ) => {
   const [socket] = useAtom(socketAtom);
   const pageIndex = pdfPainterController.getPageIndex();
-  const { pushChanges } = useBatchSocket({ socket, roomId, pageIndex });
+  const { pushChanges } = useBatchSocket({ socket, roomId, pageIndex,fileId });
 
   const editor = pdfPainterInstanceController.getEditor();
 
@@ -22,7 +23,7 @@ export const useHostSocket = (
     if (socket === null) return;
     socket.on("connect", () => {
       console.log("Connected to WebSocket server");
-      socket.emit("createRoom", { roomId: roomId });
+      socket.emit("createRoom", { roomId, fileId });
     });
     socket.on("userList", (userList: any) => {
       console.log({ userList });
@@ -31,7 +32,7 @@ export const useHostSocket = (
       socket.off("connect");
       socket.off("userList");
     };
-  }, [roomId, socket]);
+  }, [fileId, roomId, socket]);
 
   useEffect(() => {
     if (socket === null) return;

--- a/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
@@ -28,8 +28,9 @@ export const useHostSocket = (
 
     socket.on("connect", () => {
       console.log("Connected to WebSocket server");
+      socket.off("createRoom")
+      socket.emit("createRoom", { roomId: roomId });
     });
-    socket.emit("createRoom", { roomId: roomId });
     socket.on("userList", (userList: any) => {
       console.log({ userList });
     });

--- a/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
@@ -52,6 +52,11 @@ export const useParticipantSocket = (
 
   useEffect(() => {
     if (socket === null) return;
+    socket.emit("sendPageNumber", { roomId, fileId, index: pageIndex });
+  }, [fileId, pageIndex, roomId, socket]);
+
+  useEffect(() => {
+    if (socket === null) return;
 
     socket.on(
       "getAddedDraw",

--- a/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
@@ -24,17 +24,23 @@ export const useParticipantSocket = (
   } = useReceiveDrawCache(editor);
   const [socket] = useAtom(socketAtom);
   const pageIndex = pdfPainterController.getPageIndex();
-  
+
   useEffect(() => {
     setEditorFromDrawCache(pageIndex);
   }, [pageIndex, setEditorFromDrawCache]);
 
   useEffect(() => {
     if (socket === null) return;
-    socket.on("connect", () => {
+    if (socket.connected) {
       console.log("Connected to WebSocket server");
       socket.emit("joinRoom", { roomId: roomId });
-    });
+    } else {
+      socket.on("connect", () => {
+        console.log("Connected to WebSocket server");
+        socket.emit("joinRoom", { roomId: roomId });
+      });
+    }
+
     socket.on("userList", (userList: any) => {
       console.log({ userList });
     });

--- a/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
@@ -24,9 +24,7 @@ export const useParticipantSocket = (
   } = useReceiveDrawCache(editor);
   const [socket] = useAtom(socketAtom);
   const pageIndex = pdfPainterController.getPageIndex();
-  // 다른 페이지 데이터 받으면 cache에 삽입됨
-  // useEffect는 일단 호출되므로 내 페이지가 0인 경우에도 작동 -> cache에 삽입데이터가 반영됨?
-  // 아 왜 pageIndex가 순간 message.index로 바뀌는거지?
+  
   useEffect(() => {
     setEditorFromDrawCache(pageIndex);
   }, [pageIndex, setEditorFromDrawCache]);

--- a/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
@@ -11,6 +11,7 @@ import { integralRecord } from "../_utils/integralRecord";
 
 export const useParticipantSocket = (
   roomId: number | string,
+  fileId: number,
   pdfPainterInstanceController: PDFPainterInstanceController,
   pdfPainterController: PDFPainterController
 ) => {

--- a/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
@@ -34,12 +34,15 @@ export const useParticipantSocket = (
     if (socket === null) return;
     socket.on("connect", () => {
       console.log("Connected to WebSocket server");
-      socket.off("joinRoom")
       socket.emit("joinRoom", { roomId: roomId });
     });
     socket.on("userList", (userList: any) => {
       console.log({ userList });
-    })
+    });
+    return () => {
+      socket.off("connect");
+      socket.off("userList");
+    };
   }, [roomId, socket]);
 
   useEffect(() => {

--- a/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
@@ -34,11 +34,12 @@ export const useParticipantSocket = (
     if (socket === null) return;
     socket.on("connect", () => {
       console.log("Connected to WebSocket server");
+      socket.off("joinRoom")
+      socket.emit("joinRoom", { roomId: roomId });
     });
-    socket.emit("joinRoom", { roomId: roomId });
     socket.on("userList", (userList: any) => {
       console.log({ userList });
-    });
+    })
   }, [roomId, socket]);
 
   useEffect(() => {


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 [#]

## 📄 개요
- 필요한 소켓이벤트에 fileId를 받도록함
- page count를 콘솔로 찍음

## 🔁 변경 사항
### 변경 내용을 적어주세요 (커밋 번호를 적어주세요)
- connect나 방 설정 이벤트 경우 useEffect를 분리하고 필요한 의존성 배열을 받아 빈번한 이벤트리스너 해제 및 등록을 줄임
- 분명 이벤트 리스너는 등록되긴하지만 동작이 안돼 socket.connectd:boolean에 따라 조건문을 걸어줌
- 임시적으로 pagecount는 콘솔로 결과 확인하도록함, 현재 참여자가 보고있는 페이지를 호스트가 확인할수만 있게함
  - 여러명일 경우 어떤 상황이 올지는 아직 모르겠음 로컬에서 테스트하는 특성상 호스트1, 참여자1만 가능함

## 📸 동작 화면 스크린샷

## 👀 기타 논의 사항
```typescript
    if (socket.connected) {
      console.error("Connected to WebSocket server");
      socket.emit("createRoom", { roomId, fileIds: [fileId] });
    } else {
      socket.on("connect", () => {
        console.error("Connected to WebSocket server");
        socket.emit("createRoom", { roomId, fileIds: [fileId] });
      });
    }
```
왜 이런 로직변경이 필요해진지 잘 모르겠다.
아직 안정성이 떨어지므로 이런 로직으로 관리하면 좋을 것 같다
![image](https://github.com/user-attachments/assets/d5907eed-4578-4532-8c27-fc45e8ed4113)

## ⏰ 마감기한 회고
- 상당히 늦어졌다. 예상과달리 방이 재조정되지 않아 원인파악을 해야했고 fildId를 적용한 이후 connectd to websocket server 콘솔이 나오지 않았다. 