### PR TITLE
fix: init user and set rooms

### DIFF
--- a/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
@@ -21,37 +21,29 @@ export const useHostSocket = (
 
   useEffect(() => {
     if (socket === null) return;
-    if (socket.connected) {
-      console.error("Connected to WebSocket server");
+    socket.on("initUser", () => {
+      console.log("Connected to WebSocket server:", socket.id);
       socket.emit("createRoom", { roomId, fileIds: [fileId] });
-    } else {
-      socket.on("connect", () => {
-        console.error("Connected to WebSocket server");
-        socket.emit("createRoom", { roomId, fileIds: [fileId] });
-      });
-    }
-    socket.on("reconnect",()=>{
-      console.error("re")
-    })
+    });
     socket.on("userList", (userList: any) => {
       console.log({ userList });
     });
     return () => {
       socket.off("connect");
       socket.off("userList");
+      socket.off("initUser");
     };
   }, [fileId, roomId, socket]);
 
-  useEffect(()=>{
+  useEffect(() => {
     if (socket === null) return;
-    socket.on("getPageNumber",(data)=>{
-      console.log(data)
-    })
+    socket.on("getPageNumber", (data) => {
+      console.log(data);
+    });
     return () => {
       socket.off("getPageNumber");
-    }
-  },[socket])
-  
+    };
+  }, [socket]);
 
   useEffect(() => {
     if (socket === null) return;

--- a/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
@@ -31,22 +31,17 @@ export const useParticipantSocket = (
 
   useEffect(() => {
     if (socket === null) return;
-    if (socket.connected) {
-      console.log("Connected to WebSocket server");
-      socket.emit("joinRoom", { roomId: roomId });
-    } else {
-      socket.on("connect", () => {
-        console.log("Connected to WebSocket server");
-        socket.emit("joinRoom", { roomId: roomId });
-      });
-    }
-
+    socket.on("initUser", () => {
+      console.log("Connected to WebSocket server:", socket.id);
+      socket.emit("joinRoom", { roomId });
+    });
     socket.on("userList", (userList: any) => {
       console.log({ userList });
     });
     return () => {
       socket.off("connect");
       socket.off("userList");
+      socket.off("initUser");
     };
   }, [roomId, socket]);
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 [#]
#394
## 📄 개요
![image](https://github.com/user-attachments/assets/7b472ab3-1559-4832-a298-12ef606f861d)
- handleConnect이 발생했을때 유저와 방 정보를 재조정
- 유저 연결이 불안정할때 그걸 클라에서 이벤트로 처리하는 법이 없었음(있긴 하나 매우 불안정하고 복잡한 코드 탄생예정 -> 모든 케이스를 처리해야하므로)

## 🔁 변경 사항
- joinRoom와 createRoom이벤트를 initUser 이벤트를 받으면 emit
- initUser evnet 메모리 해제

## 📸 동작 화면 스크린샷

## 👀 기타 논의 사항
- 지금 방식으로 문제해결이 가능하나 과연 잠재적인 문제는 없을까?
## ⏰ 마감기한 회고
- 바로바로 백엔드와 진행 완료