### PR TITLE
feat: page number

### DIFF
--- a/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
@@ -38,13 +38,23 @@ export const useHostSocket = (
 
   useEffect(() => {
     if (socket === null) return;
-    socket.on("getPageNumber", (data) => {
+    socket.emit("sendHostPageNumber", { roomId, fileId, index: pageIndex });
+  }, [fileId, pageIndex, roomId, socket]);
+
+
+  useEffect(() => {
+    if (socket === null) return;
+    socket.on("getPartiPageNumber", (data) => {
       console.log(data);
     });
     return () => {
-      socket.off("getPageNumber");
+      socket.off("getPartiPageNumber");
     };
   }, [socket]);
+
+  useEffect(()=>{
+
+  },[])
 
   useEffect(() => {
     if (socket === null) return;

--- a/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
@@ -48,8 +48,18 @@ export const useParticipantSocket = (
 
   useEffect(() => {
     if (socket === null) return;
-    socket.emit("sendPageNumber", { roomId, fileId, index: pageIndex });
+    socket.emit("sendPartiPageNumber", { roomId, fileId, index: pageIndex });
   }, [fileId, pageIndex, roomId, socket]);
+
+  useEffect(() => {
+    if (socket === null) return;
+    socket.on("getHostPageNumber", (data) => {
+      console.log(data);
+    });
+    return () => {
+      socket.off("getHostPageNumber");
+    };
+  }, [socket]);
 
   useEffect(() => {
     if (socket === null) return;


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 [#]
close #407 
## 📄 개요
- 콘솔로 호스트와 파티시펀트간 페이지 정보 공유

## 🔁 변경 사항
- 백엔드의 이벤트 명세(partiPageNumber, hostPageNumber)대로 구현

## 📸 동작 화면 스크린샷
- 참여자가 페이지 조작시 호스트
![image](https://github.com/user-attachments/assets/d80e1ab3-4995-4067-98e1-b879f0ee1973)
- 호스트가 페이지 조작시 참여자
![image](https://github.com/user-attachments/assets/c06c0280-1db3-49a0-89d1-c5cf6c764f5a)

## 👀 기타 논의 사항
```typescript
  useEffect(() => {
    if (socket === null) return;
    socket.on("getHostPageNumber", (data) => {
      console.log(data);
    });
    return () => {
      socket.off("getHostPageNumber");
    };
  }, [socket]);
```
페이지 넘버를 받는 경우 현재 특별한 처리가 없지만 의존성 배열에 추가적으로 넣을게 없을까?
roomId와 fileId를 넣을 필요가 없을까? 
## ⏰ 마감기한 회고
- 이벤트 명세를 바꿔야하는 상황이 발생했다. 그래서 그만큼 지연이 발생했다. 일에 대한 명세를 더 상세히 논의해야겠다.