### PR TITLE
Be/418 cookie secure option

### DIFF
--- a/packages/api-server/src/auth/cookie.option.ts
+++ b/packages/api-server/src/auth/cookie.option.ts
@@ -8,6 +8,7 @@ export const CookieOptions = async (
   httpOnly: boolean;
   domain: string;
   maxAge: number;
+  secure: boolean;
 }> => {
   return {
     sameSite: 'lax',
@@ -19,5 +20,6 @@ export const CookieOptions = async (
         : type === 'refreshToken'
           ? configService.get<number>('REFRESH_TOKEN_MAX_AGE')
           : 0,
+    secure: configService.get<string>('NODE_ENV') === 'production',
   };
 };

--- a/packages/socket-server/src/socket/socket.service.ts
+++ b/packages/socket-server/src/socket/socket.service.ts
@@ -22,7 +22,7 @@ export class SocketService {
 
   async validateUser(socket: Socket): Promise<number> {
     try {
-      const cookies = socket.request.headers.cookie;
+      const cookies = socket.handshake.headers.cookie;
       if (!cookies) return 0;
       const cookieList = cookie.parse(cookies);
       const accessToken = cookieList['access_token'];


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정

## ❗️ 관련 이슈 [#]
close #418 

## 📄 개요
- 동작 환경에 따라 secure 옵션 변경

## 🔁 변경 사항
### 변경 내용을 적어주세요 (커밋 번호를 적어주세요)
- 이전에 socket server 에서 쿠키를 읽을 때, cookie.request에서 cookie를 떼왔음.
- 근데 websocket으로만 연결을 하므로, cookie.handshake로 읽어오는 게 맞는 거 같음  

## 📸 동작 화면 스크린샷

## 👀 기타 논의 사항
- 바꿔봤는데 아니면 다시 찾아봐야지
## ⏰ 마감기한 회고
