### PR TITLE
417 pdf preview

### DIFF
--- a/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
@@ -40,6 +40,8 @@ export default function HostViewer(props: ViewerPropType) {
       <PreviewPages
         pdfDocumentURL={pdfDocument.url}
         PDFPainterController={pdfPainterControllerHook.pdfPainterController}
+        getBadgeVisible={(index) => index + 1 === 1}
+        getBadgeContent={() => <>1</>}
       />
       <div
         className={css({

--- a/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
@@ -22,7 +22,7 @@ export default function HostViewer(props: ViewerPropType) {
     editorId: "Host",
     pdfPainterController: pdfPainterControllerHook.pdfPainterController,
   });
-  useHostSocket(
+  const { roomPageViewerCount } = useHostSocket(
     sessionId,
     fileId,
     pdfPainterHostInstanceControllerHook.pdfPainterInstanceController,
@@ -40,15 +40,17 @@ export default function HostViewer(props: ViewerPropType) {
       <PreviewPages
         pdfDocumentURL={pdfDocument.url}
         PDFPainterController={pdfPainterControllerHook.pdfPainterController}
-        getBadgeVisible={(index) => index + 1 === 1}
-        getBadgeContent={() => <>1</>}
+        getBadgeVisible={(index) => roomPageViewerCount.hasOwnProperty(index)}
+        getBadgeContent={(index) => {
+          return <>{index !== undefined && roomPageViewerCount[index]}</>;
+        }}
       />
       <div
         className={css({
           justifyContent: "center",
           alignItems: "center",
-          width:`calc(100% - 13rem)`,
-          height:"100%",
+          width: `calc(100% - 13rem)`,
+          height: "100%",
           display: "flex",
         })}
       >

--- a/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
@@ -47,7 +47,8 @@ export default function HostViewer(props: ViewerPropType) {
         className={css({
           justifyContent: "center",
           alignItems: "center",
-          flexGrow: 1,
+          width:`calc(100% - 13rem)`,
+          height:"100%",
           display: "flex",
         })}
       >

--- a/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
@@ -8,6 +8,8 @@ import {
   usePDFPainterInstanceController,
 } from "@/PaintPDF/components";
 import { ViewerPropType } from "../_types/ViewerType";
+import { PreviewPages } from "./PreviewPages";
+import { css } from "@/styled-system/css";
 
 export default function HostViewer(props: ViewerPropType) {
   const { fileList, sessionId } = props;
@@ -29,28 +31,38 @@ export default function HostViewer(props: ViewerPropType) {
 
   return (
     <div
-      style={{
+      className={css({
         display: "flex",
-        flexDirection: "column",
         width: "100vw",
         height: "100vh",
-        justifyContent: "center",
-        alignItems: "center",
-      }}
+      })}
     >
-      <PDFPainter
-        painterId={`${sessionId}_${pdfDocument.fileId}`}
+      <PreviewPages
         pdfDocumentURL={pdfDocument.url}
-        customPdfPainterControllerHook={pdfPainterControllerHook}
+        PDFPainterController={pdfPainterControllerHook.pdfPainterController}
+      />
+      <div
+        className={css({
+          justifyContent: "center",
+          alignItems: "center",
+          flexGrow: 1,
+          display: "flex",
+        })}
       >
-        <PainterInstanceGenerator
-          instanceId={"Host"}
-          readOnly={false}
-          customPdfPainterInstanceControllerHook={
-            pdfPainterHostInstanceControllerHook
-          }
-        />
-      </PDFPainter>
+        <PDFPainter
+          painterId={`${sessionId}_${pdfDocument.fileId}`}
+          pdfDocumentURL={pdfDocument.url}
+          customPdfPainterControllerHook={pdfPainterControllerHook}
+        >
+          <PainterInstanceGenerator
+            instanceId={"Host"}
+            readOnly={false}
+            customPdfPainterInstanceControllerHook={
+              pdfPainterHostInstanceControllerHook
+            }
+          />
+        </PDFPainter>
+      </div>
     </div>
   );
 }

--- a/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
@@ -11,6 +11,8 @@ import {
   usePDFPainterInstanceController,
 } from "@/PaintPDF/components";
 import { ViewerPropType } from "../_types/ViewerType";
+import { css } from "@/styled-system/css";
+import { PreviewPages } from "./PreviewPages";
 
 export default function ParticipantViewer(props: ViewerPropType) {
   const { fileList, sessionId } = props;
@@ -50,35 +52,50 @@ export default function ParticipantViewer(props: ViewerPropType) {
 
   return (
     <div
-      style={{
+      className={css({
         display: "flex",
-        flexDirection: "column",
         width: "100vw",
         height: "100vh",
-        justifyContent: "center",
-        alignItems: "center",
-      }}
+      })}
     >
-      <PDFPainter
-        painterId={`${sessionId}_${pdfDocument.fileId}`}
+      <PreviewPages
         pdfDocumentURL={pdfDocument.url}
-        customPdfPainterControllerHook={pdfPainterControllerHook}
+        PDFPainterController={pdfPainterControllerHook.pdfPainterController}
+        getBadgeVisible={(index) => index === hostIndex}
+        getBadgeContent={(index) => {
+          return <>{index !== undefined && hostIndex !== null && "!"}</>;
+        }}
+      />
+      <div
+        className={css({
+          justifyContent: "center",
+          alignItems: "center",
+          width: `calc(100% - 13rem)`,
+          height: "100%",
+          display: "flex",
+        })}
       >
-        <PainterInstanceGenerator
-          instanceId={"Host"}
-          readOnly={true}
-          customPdfPainterInstanceControllerHook={
-            pdfPainterHostInstanceControllerHook
-          }
-        />
-        <PainterInstanceGenerator
-          instanceId={"Participant"}
-          readOnly={false}
-          customPdfPainterInstanceControllerHook={
-            pdfPainterParticipantInstanceControllerHook
-          }
-        />
-      </PDFPainter>
+        <PDFPainter
+          painterId={`${sessionId}_${pdfDocument.fileId}`}
+          pdfDocumentURL={pdfDocument.url}
+          customPdfPainterControllerHook={pdfPainterControllerHook}
+        >
+          <PainterInstanceGenerator
+            instanceId={"Host"}
+            readOnly={true}
+            customPdfPainterInstanceControllerHook={
+              pdfPainterHostInstanceControllerHook
+            }
+          />
+          <PainterInstanceGenerator
+            instanceId={"Participant"}
+            readOnly={false}
+            customPdfPainterInstanceControllerHook={
+              pdfPainterParticipantInstanceControllerHook
+            }
+          />
+        </PDFPainter>
+      </div>
     </div>
   );
 }

--- a/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
@@ -2,7 +2,6 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { AxiosResponse } from "axios";
-import { Session, File } from "@/schema/backend.schema";
 import { apiClient } from "@/utils/axios";
 import { useParticipantSocket } from "../_hooks/useParticipantSocket";
 import {
@@ -35,7 +34,7 @@ export default function ParticipantViewer(props: ViewerPropType) {
       editorId: "Participant",
       pdfPainterController: pdfPainterControllerHook.pdfPainterController,
     });
-  useParticipantSocket(
+  const { hostIndex } = useParticipantSocket(
     sessionId,
     fileId,
     pdfPainterHostInstanceControllerHook.pdfPainterInstanceController,

--- a/packages/front-end/app/view/[sessionId]/_components/PreviewPages.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/PreviewPages.tsx
@@ -17,7 +17,7 @@ export function PreviewPages({
   pdfDocumentURL: string;
   PDFPainterController: PDFPainterController;
   getBadgeVisible: (index: number) => boolean;
-  getBadgeContent: () => ReactNode;
+  getBadgeContent: (index?: number) => ReactNode;
 }) {
   const currentPageIndex = PDFPainterController.getPageIndex();
   const pageCount = PDFPainterController.getPageCount();

--- a/packages/front-end/app/view/[sessionId]/_components/PreviewPages.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/PreviewPages.tsx
@@ -54,7 +54,7 @@ export function PreviewPages({
             }}
             currentIndex={currentPageIndex}
             isBadgeVisible={getBadgeVisible(index)}
-            badgeContent={getBadgeContent()}
+            badgeContent={getBadgeVisible(index) && getBadgeContent(index)}
           />
         ))}
       </Document>

--- a/packages/front-end/app/view/[sessionId]/_components/PreviewPages.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/PreviewPages.tsx
@@ -1,0 +1,102 @@
+import { PDFPainterController } from "@/PaintPDF/components";
+import { css } from "@/styled-system/css";
+import { EventHandler, MouseEventHandler, useRef } from "react";
+import { Document, Page } from "react-pdf";
+
+export function PreviewPages({
+  pdfDocumentURL,
+  PDFPainterController,
+}: {
+  pdfDocumentURL: string;
+  PDFPainterController: PDFPainterController;
+}) {
+  const currentPageIndex = PDFPainterController.getPageIndex();
+  const pageCount = PDFPainterController.getPageCount();
+  const loadRef = useRef<boolean>(false);
+  return (
+    <div
+      className={css({
+        width: "13rem",
+        height: "100%",
+        borderRight: "1px solid",
+        borderColor: "gray.300",
+        display: "flex",
+        overflow: "scroll",
+        justifyContent: "center",
+        bg: "gray.100",
+        padding:"1rem 0"
+      })}
+    >
+      <Document
+        file={pdfDocumentURL}
+        onLoadSuccess={() => {
+          loadRef.current = true;
+        }}
+        className={css({
+          display: "flex",
+          flexDirection: "column",
+          gap: "1rem",
+          alignItems: "center",
+        })}
+      >
+        {loadRef.current &&
+          Array.from(new Array(pageCount), (el, index) => (
+            <PageElement
+              key={`page-${index}`}
+              index={index}
+              onClick={() => {
+                PDFPainterController.setPageIndex(index);
+              }}
+              currentIndex={currentPageIndex}
+            />
+          ))}
+      </Document>
+    </div>
+  );
+}
+
+function PageElement({
+  index,
+  onClick,
+  currentIndex,
+}: {
+  index: number;
+  currentIndex: number;
+  onClick?: MouseEventHandler<HTMLDivElement>;
+}) {
+  return (
+    <div>
+      <div
+        onClick={onClick}
+        className={css({
+          cursor: "pointer",
+          border: currentIndex === index ? "2px solid white" : "",
+          outline: currentIndex === index ? "3px solid black" : "",
+          position: "relative",
+        })}
+      >
+        <Page
+          pageNumber={index + 1}
+          width={1600}
+          height={900}
+          renderTextLayer={false}
+          renderAnnotationLayer={false}
+          scale={0.1}
+        />
+        <div
+          className={css({
+            position: "absolute",
+            right: "-0.75rem",
+            top: "-1rem",
+            borderRadius: "50%",
+            width: "2rem",
+            height: "2rem",
+            border: "1px solid black",
+            backgroundColor: "white",
+          })}
+        />
+      </div>
+      <p className={css({ textAlign: "center" })}>{index + 1}</p>
+    </div>
+  );
+}

--- a/packages/front-end/app/view/[sessionId]/_components/PreviewPages.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/PreviewPages.tsx
@@ -1,7 +1,12 @@
 import { PDFPainterController } from "@/PaintPDF/components";
 import { css } from "@/styled-system/css";
-import { EventHandler, MouseEventHandler, useRef } from "react";
-import { Document, Page } from "react-pdf";
+import { MouseEventHandler, ReactNode, useRef } from "react";
+import { Document, Page, pdfjs } from "react-pdf";
+
+const options = {
+  cMapUrl: `//unpkg.com/pdfjs-dist@${pdfjs.version}/cmaps/`,
+  cMapPacked: true,
+};
 
 export function PreviewPages({
   pdfDocumentURL,
@@ -12,7 +17,6 @@ export function PreviewPages({
 }) {
   const currentPageIndex = PDFPainterController.getPageIndex();
   const pageCount = PDFPainterController.getPageCount();
-  const loadRef = useRef<boolean>(false);
   return (
     <div
       className={css({
@@ -24,32 +28,29 @@ export function PreviewPages({
         overflow: "scroll",
         justifyContent: "center",
         bg: "gray.100",
-        padding:"1rem 0"
+        padding: "1rem 0",
       })}
     >
       <Document
         file={pdfDocumentURL}
-        onLoadSuccess={() => {
-          loadRef.current = true;
-        }}
         className={css({
           display: "flex",
           flexDirection: "column",
           gap: "1rem",
           alignItems: "center",
         })}
+        options={options}
       >
-        {loadRef.current &&
-          Array.from(new Array(pageCount), (el, index) => (
-            <PageElement
-              key={`page-${index}`}
-              index={index}
-              onClick={() => {
-                PDFPainterController.setPageIndex(index);
-              }}
-              currentIndex={currentPageIndex}
-            />
-          ))}
+        {Array.from(new Array(pageCount), (el, index) => (
+          <PageElement
+            key={`page-${index}`}
+            index={index}
+            onClick={() => {
+              PDFPainterController.setPageIndex(index);
+            }}
+            currentIndex={currentPageIndex}
+          />
+        ))}
       </Document>
     </div>
   );
@@ -59,10 +60,14 @@ function PageElement({
   index,
   onClick,
   currentIndex,
+  isBadgeVisible = false,
+  badgeContent,
 }: {
   index: number;
   currentIndex: number;
   onClick?: MouseEventHandler<HTMLDivElement>;
+  isBadgeVisible?: boolean;
+  badgeContent?: ReactNode;
 }) {
   return (
     <div>
@@ -83,18 +88,25 @@ function PageElement({
           renderAnnotationLayer={false}
           scale={0.1}
         />
-        <div
-          className={css({
-            position: "absolute",
-            right: "-0.75rem",
-            top: "-1rem",
-            borderRadius: "50%",
-            width: "2rem",
-            height: "2rem",
-            border: "1px solid black",
-            backgroundColor: "white",
-          })}
-        />
+        {isBadgeVisible && (
+          <div
+            className={css({
+              position: "absolute",
+              right: "-0.75rem",
+              top: "-1rem",
+              borderRadius: "50%",
+              width: "2rem",
+              height: "2rem",
+              border: "2px solid black",
+              backgroundColor: "white",
+              display: "flex",
+              justifyContent: "center",
+              alignItems: "center",
+            })}
+          >
+            {badgeContent}
+          </div>
+        )}
       </div>
       <p className={css({ textAlign: "center" })}>{index + 1}</p>
     </div>

--- a/packages/front-end/app/view/[sessionId]/_components/PreviewPages.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/PreviewPages.tsx
@@ -11,9 +11,13 @@ const options = {
 export function PreviewPages({
   pdfDocumentURL,
   PDFPainterController,
+  getBadgeContent,
+  getBadgeVisible,
 }: {
   pdfDocumentURL: string;
   PDFPainterController: PDFPainterController;
+  getBadgeVisible: (index: number) => boolean;
+  getBadgeContent: () => ReactNode;
 }) {
   const currentPageIndex = PDFPainterController.getPageIndex();
   const pageCount = PDFPainterController.getPageCount();
@@ -49,6 +53,8 @@ export function PreviewPages({
               PDFPainterController.setPageIndex(index);
             }}
             currentIndex={currentPageIndex}
+            isBadgeVisible={getBadgeVisible(index)}
+            badgeContent={getBadgeContent()}
           />
         ))}
       </Document>

--- a/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
@@ -49,7 +49,6 @@ export const useHostSocket = (
     socket.on(
       "getPartiPageNumber",
       (data: { roomPageViewerCount: { [key in number]: number } }) => {
-        console.log(data);
         setRoomPageViewerCount({ ...data.roomPageViewerCount });
       }
     );

--- a/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useHostSocket.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useBatchSocket } from "./useBatchSocket";
 import {
   PDFPainterController,
@@ -14,6 +14,9 @@ export const useHostSocket = (
   pdfPainterController: PDFPainterController
 ) => {
   const [socket] = useAtom(socketAtom);
+  const [roomPageViewerCount, setRoomPageViewerCount] = useState<{
+    [key in number]: number;
+  }>({});
   const pageIndex = pdfPainterController.getPageIndex();
   const { pushChanges } = useBatchSocket({ socket, roomId, pageIndex, fileId });
 
@@ -41,20 +44,19 @@ export const useHostSocket = (
     socket.emit("sendHostPageNumber", { roomId, fileId, index: pageIndex });
   }, [fileId, pageIndex, roomId, socket]);
 
-
   useEffect(() => {
     if (socket === null) return;
-    socket.on("getPartiPageNumber", (data) => {
-      console.log(data);
-    });
+    socket.on(
+      "getPartiPageNumber",
+      (data: { roomPageViewerCount: { [key in number]: number } }) => {
+        console.log(data);
+        setRoomPageViewerCount({ ...data.roomPageViewerCount });
+      }
+    );
     return () => {
       socket.off("getPartiPageNumber");
     };
   }, [socket]);
-
-  useEffect(()=>{
-
-  },[])
 
   useEffect(() => {
     if (socket === null) return;
@@ -68,4 +70,6 @@ export const useHostSocket = (
       { source: "user", scope: "document" }
     );
   }, [editor, pushChanges, socket]);
+
+  return {roomPageViewerCount};
 };

--- a/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
@@ -24,13 +24,14 @@ export const useParticipantSocket = (
   } = useReceiveDrawCache(editor);
   const [socket] = useAtom(socketAtom);
   const pageIndex = pdfPainterController.getPageIndex();
+  const [hostIndex, setHostIndex] = useState<number | null>(null);
 
   useEffect(() => {
     setEditorFromDrawCache(pageIndex);
   }, [pageIndex, setEditorFromDrawCache]);
 
   useEffect(() => {
-    if (socket === null) return;   
+    if (socket === null) return;
     socket.emit("joinRoom", { roomId });
     socket.on("initUser", () => {
       console.log("Connected to WebSocket server:", socket.id);
@@ -53,9 +54,12 @@ export const useParticipantSocket = (
 
   useEffect(() => {
     if (socket === null) return;
-    socket.on("getHostPageNumber", (data) => {
-      console.log(data);
-    });
+    socket.on(
+      "getHostPageNumber",
+      (data: { fileId: number; index: number; userId: number }) => {
+        setHostIndex(data.index);
+      }
+    );
     return () => {
       socket.off("getHostPageNumber");
     };
@@ -111,4 +115,5 @@ export const useParticipantSocket = (
     socket,
     updateDrawCache,
   ]);
+  return {hostIndex}
 };

--- a/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
@@ -57,7 +57,6 @@ export const useParticipantSocket = (
     socket.on(
       "getHostPageNumber",
       (data: { fileId: number; index: number; userId: number }) => {
-        console.log(data);
         setHostIndex(data.index);
       }
     );

--- a/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
@@ -57,6 +57,7 @@ export const useParticipantSocket = (
     socket.on(
       "getHostPageNumber",
       (data: { fileId: number; index: number; userId: number }) => {
+        console.log(data);
         setHostIndex(data.index);
       }
     );


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 [#]
close #417 
## 📄 개요
### 페이지 미리보기
- 좌측에 페이지 미리보기 ui
- 누르면 해당 페이지로 이동
- 범위 벗어나면 자동으로 스크롤 시키는 로직은 그냥 구현 안함
### 호스트
- 참여자의 페이지를 받아 배지에 페이지 인원 표시
### 참여자
- 호스트의 페이지를 받아 `!`로 표시

## 🔁 변경 사항
### PreviewPages 컴포넌트
> pdf 페이지 미리보기 컴포넌트
- 미리보기시 경량화된 데이터 랜더링
- 텍스트레이어와 주석 레이어 랜더안함
- scale을 작게주면 해상도가 떨어져 경량화된다는 소리를 들음(체감이 잘 안됨)
- 어차피 width나 height만 참조하므로 비율이 세로인 pdf도 제대로 표시함
```typescript
        <Page
          pageNumber={index + 1}
          width={1600}
          height={900}
          renderTextLayer={false}
          renderAnnotationLayer={false}
          scale={0.1}
        />
```
- `getBadgeContent, getBadgeVisible,`을 통해 외부에서 배지 표시여부 및 뱃지 콘텐츠를 주입하도록 함, UI의 공통작업을 피하고 최대한 호스트 및 참가자에 따른 로직 및 UI차이만 작업하도록 함
- `badgeContent={getBadgeVisible(index) && getBadgeContent(index)}`를 통해 배지가 표시되는 조건이여야 컴포넌트 랜더함수를 호출하도록 함
### 페이지 변화
- 밑 코드는 호스트기준, 참여자도 이벤트 이름만 다르지 로직이 거의 비슷
- 페이지 번호를 받으면 재랜더하도록함
```typescript
  useEffect(() => {
    if (socket === null) return;
    socket.emit("sendHostPageNumber", { roomId, fileId, index: pageIndex });
  }, [fileId, pageIndex, roomId, socket]);

  useEffect(() => {
    if (socket === null) return;
    socket.on(
      "getPartiPageNumber",
      (data: { roomPageViewerCount: { [key in number]: number } }) => {
        setRoomPageViewerCount({ ...data.roomPageViewerCount });
      }
    );
    return () => {
      socket.off("getPartiPageNumber");
    };
  }, [socket]);
```
## 📸 동작 화면 스크린샷
![image](https://github.com/user-attachments/assets/ae3998ef-bb84-402a-9685-a51db45ecd57)

## 👀 기타 논의 사항
- 상대(참여자 기준 호스트/호스트 기준 참여자)의 페이지가 변화할때 페이지 전체를 리랜더함 -> 이를 국소화하는 로직을 추가하면 좋겠음
- 최초에 들어왔을때 아무것도 뜨지 않음
  - 왜냐하면 이벤트를 보내는 트리거는 페이지를 전환했을때이기 때문임. 상대가 페이지를 전환해야 확인 가능
  - 이를 해결하려면 어떤 방법이 좋을까? 호스트면 괜찮을거 같은데 참여자가 JoinRoom하면 호스트 페이지 넘버 이벤트도 같이 보내주면 해결 가능하긴 할듯
  - 추후 pdf페이지 미리보기는 가상화나 intersection observer을 활용해야할듯함
 - Preview는 매인 pdf에 비해 느리게 랜더되도 상관없으므로 랜더링 우선순위를 낮출 수 있는 법이 있나 궁금함
## ⏰ 마감기한 회고
- 오늘 끝냈지만 내 예상 작업량보다 더 많은 것들을 신경써야하고 구현해야했다.