### PR TITLE
425 login redirect

### DIFF
--- a/packages/front-end/app/(sidebar-pages)/layout.tsx
+++ b/packages/front-end/app/(sidebar-pages)/layout.tsx
@@ -10,29 +10,8 @@ export default function Layout({
 }: Readonly<{ children: ReactNode }>) {
   const accountController = useAccountController();
 
-  if (!accountController.account) {
-    if (!accountController.isLoading) {
-      accountController.goToLogin();
-    }
-    return (
-      <div
-        className={css({
-          display: "flex",
-          width: "100%",
-          height: "100%",
-          justifyContent: "center",
-          alignItems: "center",
-        })}
-      >
-        <div
-          className={css({
-            fontSize: "2em",
-          })}
-        >
-          App Loading Skeleton UI
-        </div>
-      </div>
-    ); //need fix
+  if (accountController.isError) {
+    accountController.goToLogin();
   }
 
   return (

--- a/packages/front-end/app/(sidebar-pages)/layout.tsx
+++ b/packages/front-end/app/(sidebar-pages)/layout.tsx
@@ -10,6 +10,28 @@ export default function Layout({
 }: Readonly<{ children: ReactNode }>) {
   const accountController = useAccountController();
 
+  if (accountController.isLoading) {
+    return (
+      <div
+        className={css({
+          display: "flex",
+          width: "100%",
+          height: "100%",
+          justifyContent: "center",
+          alignItems: "center",
+        })}
+      >
+        <div
+          className={css({
+            fontSize: "2em",
+          })}
+        >
+          User Profile Loading Skeleton UI
+        </div>
+      </div>
+    );
+  }
+
   if (accountController.isError) {
     accountController.goToLogin();
   }

--- a/packages/front-end/app/(sidebar-pages)/layout.tsx
+++ b/packages/front-end/app/(sidebar-pages)/layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ReactNode, Suspense } from "react";
+import { ReactNode, Suspense, useEffect } from "react";
 import { css } from "@/styled-system/css";
 import Sidebar from "@/app/(sidebar-pages)/_components/Sidebar";
 import { useAccountController } from "@/hook/useAccount";
@@ -9,6 +9,10 @@ export default function Layout({
   children,
 }: Readonly<{ children: ReactNode }>) {
   const accountController = useAccountController();
+
+  if (accountController.isError) {
+    accountController.goToLogin();
+  }
 
   if (accountController.isLoading) {
     return (
@@ -30,10 +34,6 @@ export default function Layout({
         </div>
       </div>
     );
-  }
-
-  if (accountController.isError) {
-    accountController.goToLogin();
   }
 
   return (

--- a/packages/front-end/app/login/loading.tsx
+++ b/packages/front-end/app/login/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading(){
+    return <h1>로딩...</h1>
+}

--- a/packages/front-end/app/login/page.tsx
+++ b/packages/front-end/app/login/page.tsx
@@ -3,8 +3,13 @@
 import { css } from "@/styled-system/css";
 import LoginButton from "./_components/LoginButton";
 import { PROJECT_NAME } from "@/const/config";
+import { useAccountController } from "@/hook/useAccount";
 
 export default function Page() {
+  const accountController = useAccountController();
+  if (accountController.account) {
+    accountController.goToDashboard();
+  }
   return (
     <div
       className={css({

--- a/packages/front-end/app/login/page.tsx
+++ b/packages/front-end/app/login/page.tsx
@@ -4,12 +4,17 @@ import { css } from "@/styled-system/css";
 import LoginButton from "./_components/LoginButton";
 import { PROJECT_NAME } from "@/const/config";
 import { useAccountController } from "@/hook/useAccount";
+import { useEffect } from "react";
 
 export default function Page() {
   const accountController = useAccountController();
-  if (accountController.account) {
+  useEffect(()=>{
+    console.log(accountController)
+      if (accountController.account) {
     accountController.goToDashboard();
   }
+  },[accountController])
+
   return (
     <div
       className={css({

--- a/packages/front-end/app/login/page.tsx
+++ b/packages/front-end/app/login/page.tsx
@@ -4,16 +4,12 @@ import { css } from "@/styled-system/css";
 import LoginButton from "./_components/LoginButton";
 import { PROJECT_NAME } from "@/const/config";
 import { useAccountController } from "@/hook/useAccount";
-import { useEffect } from "react";
 
 export default function Page() {
   const accountController = useAccountController();
-  useEffect(()=>{
-    console.log(accountController)
-      if (accountController.account) {
+  if (accountController.account) {
     accountController.goToDashboard();
   }
-  },[accountController])
 
   return (
     <div

--- a/packages/front-end/app/logout/page.tsx
+++ b/packages/front-end/app/logout/page.tsx
@@ -12,7 +12,7 @@ export default function Page() {
   const logoutMutate = useMutation({
     mutationFn: async () => await apiClient.post("/auth/logout"),
     onSuccess: () => {
-      queryClient.invalidateQueries();
+      queryClient.clear();
       router.push("/");
     },
     onError: (error) => {

--- a/packages/front-end/app/page.tsx
+++ b/packages/front-end/app/page.tsx
@@ -10,7 +10,7 @@ export default function Page() {
         <Link href={"/login"}>Login</Link>
       </div>
       <div>
-        <Link href={"/dashboard"} prefetch={false}>Dashboard</Link>
+        <Link href={"/dashboard"}>Dashboard</Link>
       </div>
     </main>
   );

--- a/packages/front-end/app/page.tsx
+++ b/packages/front-end/app/page.tsx
@@ -10,7 +10,7 @@ export default function Page() {
         <Link href={"/login"}>Login</Link>
       </div>
       <div>
-        <Link href={"/dashboard"}>Dashboard</Link>
+        <Link href={"/dashboard"} prefetch={false}>Dashboard</Link>
       </div>
     </main>
   );

--- a/packages/front-end/app/view/[sessionId]/error.tsx
+++ b/packages/front-end/app/view/[sessionId]/error.tsx
@@ -1,10 +1,27 @@
 "use client";
+
+import { useRouter } from "@/hook/useRouter";
+import { useCallback, useEffect } from "react";
+
 export default function Error({
   error,
   reset,
 }: {
-  error: Error & { digest?: string };
+  error: Error & { digest?: string; status: number };
   reset: () => void;
 }) {
+  const router = useRouter();
+  const getLoginURL = useCallback(() => {
+    return `/login?url=${encodeURIComponent(`${router.pathname}?${router.query.toString()}`)}`; //need fix
+  }, [router]);
+  const goToLogin = useCallback(() => {
+    router.push(getLoginURL());
+  }, [router, getLoginURL]);
+  useEffect(()=>{
+    if (error.status === 401) {
+      goToLogin();
+    }
+  
+  },[error.status, goToLogin])
   return <h1>{error.message}</h1>;
 }

--- a/packages/front-end/app/view/[sessionId]/loading.tsx
+++ b/packages/front-end/app/view/[sessionId]/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading(){
+    return <h1>로딩...</h1>
+}

--- a/packages/front-end/app/view/[sessionId]/page.tsx
+++ b/packages/front-end/app/view/[sessionId]/page.tsx
@@ -6,10 +6,11 @@ import HostViewer from "./_components/HostViewer";
 import { useQueries } from "@tanstack/react-query";
 import { apiClient } from "@/utils/axios";
 import ParticipantViewer from "./_components/ParticipantViewer";
-import { useAtom, useSetAtom } from "jotai";
+import { useAtom, } from "jotai";
 import { socketAtom } from "@/client/socketAtom";
 import { useEffect } from "react";
 import { io } from "socket.io-client";
+
 
 export default function Page({ params }: { params: { sessionId: string } }) {
   const [userQuery, sessionQuery] = useQueries({
@@ -17,7 +18,7 @@ export default function Page({ params }: { params: { sessionId: string } }) {
       {
         queryKey: ["user", "profile"],
         queryFn: async () => await apiClient.get<User>("/user/profile"),
-        throwOnError: true,
+        throwOnError:true,
       },
       {
         queryKey: ["session", params.sessionId],
@@ -44,6 +45,7 @@ export default function Page({ params }: { params: { sessionId: string } }) {
   if (userQuery.isLoading || sessionQuery.isLoading) {
     return <h1>로딩...</h1>;
   }
+
   if (userQuery.data === undefined || sessionQuery.data === undefined) {
     return <></>;
   }

--- a/packages/front-end/hook/useAccount.tsx
+++ b/packages/front-end/hook/useAccount.tsx
@@ -13,6 +13,7 @@ const AccountContext = createContext<{
   logout: () => void;
   getLoginURL: () => string;
   goToLogin: () => void;
+  goToDashboard: () => void;
   isLoading: boolean;
   account: User | null;
   isError: null | boolean;
@@ -21,6 +22,7 @@ const AccountContext = createContext<{
   logout: () => {},
   getLoginURL: () => "",
   goToLogin: () => {},
+  goToDashboard: () => {},
   isLoading: true,
   account: null,
   isError: false,
@@ -53,6 +55,10 @@ export const AccountProvider = ({ children }: { children: ReactNode }) => {
     router.push(getLoginURL());
   }, [router, getLoginURL]);
 
+  const goToDashboard = useCallback(() => {
+    router.push("/dashboard");
+  }, [router]);
+
   const data: User | null = response?.data || null;
 
   return (
@@ -62,6 +68,7 @@ export const AccountProvider = ({ children }: { children: ReactNode }) => {
         logout: () => {}, //need fix
         getLoginURL: getLoginURL,
         goToLogin: goToLogin,
+        goToDashboard: goToDashboard,
         isLoading: isLoading,
         account: data,
         isError: isError,

--- a/packages/front-end/hook/useAccount.tsx
+++ b/packages/front-end/hook/useAccount.tsx
@@ -6,6 +6,7 @@ import { AxiosResponse } from "axios";
 import { User } from "@/schema/backend.schema";
 import { apiClient } from "@/utils/axios";
 import { useRouter } from "@/hook/useRouter";
+import { css } from "@/styled-system/css";
 
 const AccountContext = createContext<{
   updateAccount: () => void;
@@ -14,6 +15,7 @@ const AccountContext = createContext<{
   goToLogin: () => void;
   isLoading: boolean;
   account: User | null;
+  isError: null | boolean;
 }>({
   updateAccount: () => {},
   logout: () => {},
@@ -21,6 +23,7 @@ const AccountContext = createContext<{
   goToLogin: () => {},
   isLoading: true,
   account: null,
+  isError: false,
 });
 
 export const useAccount = () => {
@@ -32,7 +35,11 @@ export const useAccountController = () => {
 };
 
 export const AccountProvider = ({ children }: { children: ReactNode }) => {
-  const { data: response, isLoading } = useQuery<AxiosResponse<User>>({
+  const {
+    data: response,
+    isLoading,
+    isError,
+  } = useQuery<AxiosResponse<User>>({
     queryKey: ["user", "profile"],
     queryFn: async () => await apiClient.get("/user/profile"),
   });
@@ -48,6 +55,28 @@ export const AccountProvider = ({ children }: { children: ReactNode }) => {
 
   const data: User | null = response?.data || null;
 
+  if (isLoading) {
+    return (
+      <div
+        className={css({
+          display: "flex",
+          width: "100%",
+          height: "100%",
+          justifyContent: "center",
+          alignItems: "center",
+        })}
+      >
+        <div
+          className={css({
+            fontSize: "2em",
+          })}
+        >
+          User Profile Loading Skeleton UI
+        </div>
+      </div>
+    );
+  }
+
   return (
     <AccountContext.Provider
       value={{
@@ -57,6 +86,7 @@ export const AccountProvider = ({ children }: { children: ReactNode }) => {
         goToLogin: goToLogin,
         isLoading: isLoading,
         account: data,
+        isError: isError,
       }}
     >
       {children}

--- a/packages/front-end/hook/useAccount.tsx
+++ b/packages/front-end/hook/useAccount.tsx
@@ -55,28 +55,6 @@ export const AccountProvider = ({ children }: { children: ReactNode }) => {
 
   const data: User | null = response?.data || null;
 
-  if (isLoading) {
-    return (
-      <div
-        className={css({
-          display: "flex",
-          width: "100%",
-          height: "100%",
-          justifyContent: "center",
-          alignItems: "center",
-        })}
-      >
-        <div
-          className={css({
-            fontSize: "2em",
-          })}
-        >
-          User Profile Loading Skeleton UI
-        </div>
-      </div>
-    );
-  }
-
   return (
     <AccountContext.Provider
       value={{


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 [#]
close #425
## 📄 개요
- /login 에 로그인한 유저 접속시 /dashboard로 리다이렉트
- view/sessionId에 미로그인 유저 접속시 /login으로 리다이렉트

## 🔁 변경 사항
### view/sessionID
- useAccount.tsx:59 Warning: Cannot update a component (`Router`) while rendering a different component (`Page`). To locate the bad setState() call inside `Page`, follow the stack trace as described in [https://reactjs.org/link/setstate-in-render](https://reactjs.org/link/setstate-in-render) 에러 발생
- 그 원인은 useQueries에 ["user", "profile"]을 불러오고 있기 때문
- 기존 hook으로 이를 격리하기에 어렵다고 판단해 우선 라우팅 로직만 따와서 errorboundary에서 401코드일때 처리
- 만약에 ["session", params.sessionId]도 로그인한 상태에서 받아와야한다면 로직 수정 후 hook으로 관리 가능할듯
- 아니면 waterfall이 심하지 않다면(2개 요청만 병렬처리) 수정 가능
### useAccount hook
- error 상태 명시가 가능한 isError 필드 추가
- 로그인한 유저를 위해 대쉬보드로 라우팅하기 위한 메서드 추가, router을 그대로 리턴하기 보단 해당 방법이 적절하다 판단
- 또한 해당 hook엔 useRouter가 내부에 사용되므로 Suspense나 loading.tsx를 사용해야함
### logout
- `queryClient.clear();` 필요
- invalidateQueries로 전체 쿼리키를 초기화해도 쿼리키 초기화만되고 context에 존재하는 상태(useAccount에서 data fetching한 서버 상태)는 초기화안됨
- 만약 유저가 로그인 -> 로그아웃 -> next/link의 <Link/>로 라우팅하는 경우, 서버에선 401에러가 나오지만 전역상태엔 유저 정보가 남음
  - 이 경우 무한 리다이렉션이 걸림(/login과 /dashboard UI가 깜빡거리는 눈뽕)
  - 따라서 clear()을 이용해 전역상태까지 초기화함
 
## 📸 동작 화면 스크린샷

## 👀 기타 논의 사항
- useAccount.tsx:59 Warning: Cannot update a component (`Router`) while rendering a different component (`Page`). To locate the bad setState() call inside `Page`, follow the stack trace as described in [https://reactjs.org/link/setstate-in-render](https://reactjs.org/link/setstate-in-render) 에러는 지금도 어디선가 발생, ["user", "profile"] 쿼리키 사용한 요청은 무조건 hook을 사용하도록 강제해야함, 현재 에러가 나와도 view/sessionId말곤 큰 문제 못느낌
  - view/sessionId에선 nextjs 기본 error UI가 나오긴 함 
  - errorboundary 사용한 곳 있으면 거기로 잡히려나? 그럴 것 같긴한데 확신은 없음
- 전역상태를 이용해 상태 관리시 react-query를 사용한 상태와 충돌이 나지 않도록 관리 체계가 필요
- view/sessionId에 hook을 사용하는게 좋을지?
## ⏰ 마감기한 회고
- 오늘안에 끝냈으나, 예상치 못한 버그로 약간 오래걸림