### PR TITLE
feat: session form error

### DIFF
--- a/packages/front-end/app/(sidebar-pages)/sessions/_components/SessionFormTemplate.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/_components/SessionFormTemplate.tsx
@@ -11,6 +11,7 @@ import { SessionFormType } from "@/type/SessionFormType";
 import { UseMutationResult } from "@tanstack/react-query";
 import { AxiosResponse } from "axios";
 import { overlay } from "overlay-kit";
+import { ReactNode, useState } from "react";
 
 export function SessionFormTemplate({
   useFormDataResult,
@@ -24,7 +25,11 @@ export function SessionFormTemplate({
     unknown
   >;
 }) {
-  const { unControlledDataRef, controlledData,idRef } = useFormDataResult;
+  const { unControlledDataRef, controlledData, idRef } = useFormDataResult;
+  const [error, setError] = useState({
+    sessionName: false,
+    sessionFiles: false,
+  });
   const handleFileButtonClick = () => {
     overlay.open(
       ({ isOpen, close }) => (
@@ -50,45 +55,100 @@ export function SessionFormTemplate({
       })}
       onSubmit={(e) => {
         e.preventDefault();
+        const { sessionName, sessionFiles } = unControlledDataRef.current;
+        const submitError = { sessionFiles: false, sessionName: false };
+        if (!sessionName.trim()) {
+          submitError.sessionName = true;
+        }
+        if (sessionFiles.length === 0) {
+          submitError.sessionFiles = true;
+        }
+        if (submitError.sessionFiles || submitError.sessionName) {
+          setError({ ...submitError });
+          return;
+        }
         formMutation.mutate({
-          sessionName: unControlledDataRef.current.sessionName,
-          sessionFileIds: unControlledDataRef.current.sessionFiles.map(
-            (file) => file.fileId
-          ),
+          sessionName: sessionName,
+          sessionFileIds: sessionFiles.map((file) => file.fileId),
         });
       }}
     >
-      <Label htmlFor="session-title">세션 제목</Label>
-      <LineEdit
-        id="session-title"
-        name="session-title"
-        placeholder="세션 제목을 입력해주세요"
-        onChange={handleInputChange}
-        className={css({ height: "3em" })}
-        defaultValue={unControlledDataRef.current.sessionName}
-      />
-      <Label htmlFor="select-file">강의 자료 선택</Label>
-      <Button
-        id="select-file"
-        name="select-file"
-        type="button"
-        onClick={handleFileButtonClick}
-        className={css({
-          height: "3em",
-          backgroundColor: "green.600",
-        })}
+      <ControlContainer
+        labelText="세션 제목"
+        htmlFor="session-title"
+        errorText="세션 제목을 입력해주세요."
+        isError={error.sessionName}
       >
-        자료 선택
-      </Button>
-      <Label>현재 선택한 파일</Label>
-      <Paragraph>
-        {controlledData.sessionFiles.length > 0
-          ? controlledData.sessionFiles[0].name
-          : "현재 선택한 파일이 없습니다."}
-      </Paragraph>
+        <LineEdit
+          id="session-title"
+          name="session-title"
+          placeholder="세션 제목을 입력해주세요"
+          onChange={handleInputChange}
+          className={css({ height: "3em" })}
+          defaultValue={unControlledDataRef.current.sessionName}
+        />
+      </ControlContainer>
+      <ControlContainer
+        labelText="강의 자료 선택"
+        htmlFor="select-file"
+        errorText="세션 파일을 선택해주세요."
+        isError={error.sessionFiles}
+      >
+        <Button
+          id="select-file"
+          name="select-file"
+          type="button"
+          onClick={handleFileButtonClick}
+          className={css({
+            height: "3em",
+            backgroundColor: "green.600",
+          })}
+        >
+          자료 선택
+        </Button>
+      </ControlContainer>
+      <ControlContainer labelText="현재 선택한 파일">
+        <Paragraph>
+          {controlledData.sessionFiles.length > 0
+            ? controlledData.sessionFiles[0].name
+            : "현재 선택한 파일이 없습니다."}
+        </Paragraph>
+      </ControlContainer>
       <Button type="submit" className={css({ height: "3em" })}>
         세션 시작
       </Button>
     </form>
+  );
+}
+
+function ControlContainer({
+  children,
+  labelText,
+  htmlFor,
+  errorText,
+  isError,
+  height,
+}: {
+  children?: ReactNode;
+  labelText?: string;
+  htmlFor?: string;
+  errorText?: string;
+  isError?: boolean;
+  height?: React.CSSProperties["height"];
+}) {
+  return (
+    <div
+      className={css({
+        display: "flex",
+        flexDirection: "column",
+        gap: "0.75rem",
+        width: "100%",
+        height: height,
+      })}
+    >
+      <Label htmlFor={htmlFor}>{labelText}</Label>
+      {children}
+      {!!isError && <p className={css({ color: "red.500" })}>{errorText}</p>}
+    </div>
   );
 }

--- a/packages/front-end/app/(sidebar-pages)/sessions/_components/SessionFormTemplate.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/_components/SessionFormTemplate.tsx
@@ -107,7 +107,7 @@ export function SessionFormTemplate({
           자료 선택
         </Button>
       </ControlContainer>
-      <ControlContainer labelText="현재 선택한 파일">
+      <ControlContainer labelText="현재 선택한 파일" height="auto">
         <Paragraph>
           {controlledData.sessionFiles.length > 0
             ? controlledData.sessionFiles[0].name
@@ -127,7 +127,7 @@ function ControlContainer({
   htmlFor,
   errorText,
   isError,
-  height,
+  height="135px",
 }: {
   children?: ReactNode;
   labelText?: string;


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 [#]
close #429 
## 📄 개요
- 세션 폼 검증 로직
  - ControlContainer 컴포넌트
  - [error,setError] state
  - onSubmit

## 🔁 변경 사항
### ControlContainer
```typecript
function ControlContainer({
  children,
  labelText,
  htmlFor,
  errorText,
  isError,
  height="135px",
}: {
  children?: ReactNode;
  labelText?: string;
  htmlFor?: string;
  errorText?: string;
  isError?: boolean;
  height?: React.CSSProperties["height"];
}) {
  return (
    <div
      className={css({
        display: "flex",
        flexDirection: "column",
        gap: "0.75rem",
        width: "100%",
        height: height,
      })}
    >
      <Label htmlFor={htmlFor}>{labelText}</Label>
      {children}
      {!!isError && <p className={css({ color: "red.500" })}>{errorText}</p>}
    </div>
  );
}
```
- 폼 각각의 control과 에러 ui를 통일성있게 작성하기 위함
- 에러 메시지 표시시 CLS가 발생해 기본 높이 설정(135px)
- 에러 텍스트를 커스텀 가능, 만약 에러=true라면 표시
- children에는 관련 input이나 button UI가 들어감

### error state
```typescript
  const [error, setError] = useState({
    sessionName: false,
    sessionFiles: false,
  });
```
- 세션 폼 필드에 boolean이 붙은 형태
- 커스텀 로직을 위해 input tag 그 자체를 이용하기 보단 해당 상태 이용
- 특히, 파일 선택은 button을 눌러 표시되는 modal로 이루어지므로 Input tag 자체로 검증하는 것은 어려움
- 타입세이프티 및 반복되는 로직이 존재 이를 리팩토링할 방법은 생각나긴하지만 에러 처리시 더 이쁜 로직이 몇개 구상되므로 일단 남겨둠

### onSubmit
```typescript
      onSubmit={(e) => {
        e.preventDefault();
        const { sessionName, sessionFiles } = unControlledDataRef.current;
        const submitError = { sessionFiles: false, sessionName: false };
        if (!sessionName.trim()) {
          submitError.sessionName = true;
        }
        if (sessionFiles.length === 0) {
          submitError.sessionFiles = true;
        }
        if (submitError.sessionFiles || submitError.sessionName) {
          setError({ ...submitError });
          return;
        }
        formMutation.mutate({
          sessionName: sessionName,
          sessionFileIds: sessionFiles.map((file) => file.fileId),
        });
      }}
```
- 에러가 발생시 리랜더링해서 에러 UI 표시
- 에러가 발생시 서버에 폼 제출 안함
- 기본적인 검증 로직은
  - 세션 이름: 공백지웠을 때 텍스트 존재
  - 세션 파일: 파일이 존재

## 📸 동작 화면 스크린샷
<img width="1213" alt="스크린샷 2024-09-29 오후 6 35 55" src="https://github.com/user-attachments/assets/2e759ee5-afb7-4ba6-9a46-ebbfc2f42501">
- 에러가 표시되고 POST/PATCH를 안하는 모습

## 👀 기타 논의 사항
- onSubmit 길이가 너무 길어 따로 뺄까 싶음 JSX읽을 때 약간 힘들기 시작

## ⏰ 마감기한 회고
- 더 좋은 로직들이 많으나, 요구 사항 자체가 간단해 그에 맞게 빠르게 구현해 몇분 안걸렸다.