### PR TITLE
431 profile validate

### DIFF
--- a/packages/front-end/app/(sidebar-pages)/sessions/join/page.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/join/page.tsx
@@ -11,6 +11,10 @@ import { useRouter } from "@/hook/useRouter";
 
 export default function Page() {
   const [sessionId, setSessionId] = useState("");
+  const [status, setStatus] = useState<{
+    status: "notice" | "error";
+    text: string;
+  } | null>(null);
   const router = useRouter();
   return (
     <div
@@ -50,7 +54,7 @@ export default function Page() {
                 flexGrow: 1,
                 height: "inherit",
               })}
-              placeholder="세션 아이디를 입력해 주세요."
+              placeholder="세션 코드를 입력해 주세요."
               value={sessionId}
               onChange={(event) => setSessionId(event.target.value)}
               name="session-code"
@@ -60,14 +64,30 @@ export default function Page() {
               className={css({
                 height: "inherit",
               })}
-              disabled={sessionId === ""}
+              disabled={sessionId.trim() === ""}
               onClick={() => {
+                if (sessionId.trim() === "") {
+                  setStatus({
+                    status: "error",
+                    text: "세션 코드를 입력해주세요.",
+                  });
+                  return;
+                }
+                setStatus({ status: "notice", text: "세션을 로딩중입니다." });
                 router.push(`/view/${sessionId}`);
               }}
             >
               {"접속하기"}
             </Button>
           </div>
+          <p
+            className={css({
+              height: "1rem",
+              color: status?.status === "error" ? "red.500" : "green",
+            })}
+          >
+            {status?.text}
+          </p>
         </div>
       </div>
     </div>

--- a/packages/front-end/app/(sidebar-pages)/settings/_components/UserProfileSettings.tsx
+++ b/packages/front-end/app/(sidebar-pages)/settings/_components/UserProfileSettings.tsx
@@ -39,8 +39,11 @@ const UserProfileSettings = () => {
         setImageSrc(reader.result as string);
       };
       reader.onerror = () => {
-        console.error(reader.error);
+        if (reader.error) {
+          setError(reader.error.message);
+        }
       };
+
       reader.readAsDataURL(file);
     }
   };
@@ -149,17 +152,17 @@ const UserProfileSettings = () => {
           />
         </div>
       </div>
-      
-        <p
-          className={css({
-            height: "1rem",
-            fontSize: "1rem",
-            color: "red.500",
-          })}
-        >
-          {error && error}
-        </p>
-      
+
+      <p
+        className={css({
+          height: "1rem",
+          fontSize: "1rem",
+          color: "red.500",
+        })}
+      >
+        {error && error}
+      </p>
+
       <Button type="submit" className={css({ height: "50px" })}>
         저장하기
       </Button>

--- a/packages/front-end/app/(sidebar-pages)/settings/_components/UserProfileSettings.tsx
+++ b/packages/front-end/app/(sidebar-pages)/settings/_components/UserProfileSettings.tsx
@@ -17,6 +17,7 @@ const UserProfileSettings = () => {
   const fileInputRef = useRef<null | HTMLInputElement>(null);
   const formRef = useRef<null | HTMLFormElement>(null);
   const [imageSrc, setImageSrc] = useState<string>(account?.profileUrl || "");
+  const [error, setError] = useState<string | null>(null);
   const queryClient = useQueryClient();
   const formMutation = useMutation({
     mutationFn: async (body: FormData) =>
@@ -26,7 +27,7 @@ const UserProfileSettings = () => {
       queryClient.refetchQueries({ queryKey: ["user", "profile"] });
     },
     onError: (e) => {
-      console.error(e);
+      setError(`프로필 저장 실패: ${e.message}`);
     },
   });
 
@@ -36,6 +37,9 @@ const UserProfileSettings = () => {
       const reader = new FileReader();
       reader.onload = () => {
         setImageSrc(reader.result as string);
+      };
+      reader.onerror = () => {
+        console.error(reader.error);
       };
       reader.readAsDataURL(file);
     }
@@ -55,6 +59,11 @@ const UserProfileSettings = () => {
         e.preventDefault();
         if (formRef.current) {
           const formData = new FormData(formRef.current);
+          const nickname = formData.get("nickname") as string;
+          if (nickname.trim() === "") {
+            setError("닉네임을 입력해주세요.");
+            return;
+          }
           formMutation.mutate(formData);
         }
       }}
@@ -127,6 +136,7 @@ const UserProfileSettings = () => {
               display: "block",
               fontSize: "1em",
             })}
+            htmlFor="nickname"
           >
             닉네임
           </Label>
@@ -135,9 +145,21 @@ const UserProfileSettings = () => {
             defaultValue={account?.nickname || ""}
             name="nickname"
             className={css({ flex: 1, height: "3em" })}
+            id="nickname"
           />
         </div>
       </div>
+      
+        <p
+          className={css({
+            height: "1rem",
+            fontSize: "1rem",
+            color: "red.500",
+          })}
+        >
+          {error && error}
+        </p>
+      
       <Button type="submit" className={css({ height: "50px" })}>
         저장하기
       </Button>

--- a/packages/front-end/components/ProfileImage.tsx
+++ b/packages/front-end/components/ProfileImage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image, { ImageProps } from "next/image";
-import { forwardRef, useState } from "react";
+import { forwardRef, useEffect, useState } from "react";
 
 const defaultSrc = "/profile-default.jpg";
 const errorSrc = "/profile-default.jpg";
@@ -14,6 +14,11 @@ export const ProfileImage = forwardRef<HTMLImageElement | null, ImageProps>(
     const [imgSrc, setImgSrc] = useState(isValidSrc ? src : defaultSrc);
     const [isError, setIsError] = useState(false);
 
+    useEffect(()=>{
+      const isValidSrc = src && typeof src === "string" && src.trim() !== "";
+    setImgSrc(isValidSrc ? src : defaultSrc);
+    },[src])
+   
     const handleError = () => {
       if (isError) return;
       setImgSrc(errorSrc);


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 [#]
close #431 
## 📄 개요
- 프로필이미지가 바뀌지 않는 버그
- 에러 처리

## 🔁 변경 사항
- src에 따라 프로필이 재랜더되도록함
```
    useEffect(()=>{
      const isValidSrc = src && typeof src === "string" && src.trim() !== "";
    setImgSrc(isValidSrc ? src : defaultSrc);
    },[src])
```
- 파일리더, 서버 응답오류, 닉네임을 공백으로 뒀을 때 에러 처리
- 세션코드의 경우 trim()으로 빈 텍스트 상세 검증 & 로딩 UI
  - 어차피 입력안했으면 disable button이던데?
## 📸 동작 화면 스크린샷
![image](https://github.com/user-attachments/assets/657a7217-bcf2-45a0-9504-89ab575cc815)
(쿠키를 다 지우고 보냈을 때 에러)
## 👀 기타 논의 사항

## ⏰ 마감기한 회고
- 요구사항 간단 -> 얼마안걸림