### PR TITLE
434 chase host page

### DIFF
--- a/packages/front-end/PaintPDF/components/PDFPainter/PDFPainter.tsx
+++ b/packages/front-end/PaintPDF/components/PDFPainter/PDFPainter.tsx
@@ -128,7 +128,6 @@ const PDFPainterComponent = ({
 					})}
 				</div>
 			</div>
-			<PDFPainterControlBar pdfPainterController={pdfPainterController} />
 		</div>
 	);
 };

--- a/packages/front-end/PaintPDF/components/PDFPainter/PDFPainter.tsx
+++ b/packages/front-end/PaintPDF/components/PDFPainter/PDFPainter.tsx
@@ -1,135 +1,172 @@
-import { useEffect, useRef, useCallback, memo, isValidElement, Children, ReactNode } from "react";
+import {
+  useEffect,
+  useRef,
+  useCallback,
+  memo,
+  isValidElement,
+  Children,
+  ReactNode,
+} from "react";
 import { PDFRenderSize } from "../PDF/types";
-import { PDFPainterControllerHook } from "./types";
+import {
+  PDFPainterControllerHook,
+  PDFPainterInstanceControllerHook,
+} from "./types";
 import { usePDFPainterController } from "./hooks/usePDFPainterController";
 import { PDFViewer } from "../PDF/PDFViewer";
 import { PainterInstance } from "./PainterInstance";
 import { PDFPainterControlBar } from "./PDFPainterControlBar";
 const PDFPainterComponent = ({
-	painterId,
-	pdfDocumentURL,
-	customPdfPainterControllerHook,
-	children,
+  painterId,
+  pdfDocumentURL,
+  customPdfPainterControllerHook,
+  children,
 }: {
-	painterId: string;
-	pdfDocumentURL: string;
-	customPdfPainterControllerHook?: PDFPainterControllerHook;
-	children?: ReactNode;
+  painterId: string;
+  pdfDocumentURL: string;
+  customPdfPainterControllerHook?: PDFPainterControllerHook;
+  children?: ReactNode;
 }) => {
-	const painterElement = useRef<HTMLDivElement | null>(null);
+  const painterElement = useRef<HTMLDivElement | null>(null);
 
-	const defaultPdfPainterControllerHook = usePDFPainterController({ painterId: painterId });
-	const pdfPainterControllerHook = customPdfPainterControllerHook || defaultPdfPainterControllerHook;
-	const { pdfPainterController } = pdfPainterControllerHook;
+  const defaultPdfPainterControllerHook = usePDFPainterController({
+    painterId: painterId,
+  });
+  const pdfPainterControllerHook =
+    customPdfPainterControllerHook || defaultPdfPainterControllerHook;
+  const { pdfPainterController } = pdfPainterControllerHook;
 
-	const updateDisplaySize = useCallback(() => {
-		const currentPdfPage = pdfPainterController.getPage();
-		if (painterElement.current && currentPdfPage) {
-			const elementWidth = painterElement.current.offsetWidth;
-			const elementHeight = painterElement.current.offsetHeight;
-			const pdfPageWidth = currentPdfPage.originalWidth;
-			const pdfPageHeight = currentPdfPage.originalHeight;
-			const elementRatio = elementWidth / elementHeight;
-			const pdfPageRatio = pdfPageWidth / pdfPageHeight;
-			let newDisplaySize: PDFRenderSize;
-			if (pdfPageRatio > elementRatio) {
-				newDisplaySize = {
-					width: elementWidth,
-					height: elementWidth / pdfPageRatio,
-				};
-			} else {
-				newDisplaySize = {
-					width: elementHeight * pdfPageRatio,
-					height: elementHeight,
-				};
-			}
-			const currentDisplaySize = pdfPainterController.getRenderSize();
-			if (newDisplaySize.width !== currentDisplaySize.width || newDisplaySize.height !== currentDisplaySize.height) {
-				pdfPainterController.setRenderSize(newDisplaySize);
-			}
-		}
-	}, [pdfPainterController]);
+  const updateDisplaySize = useCallback(() => {
+    const currentPdfPage = pdfPainterController.getPage();
+    if (painterElement.current && currentPdfPage) {
+      const elementWidth = painterElement.current.offsetWidth;
+      const elementHeight = painterElement.current.offsetHeight;
+      const pdfPageWidth = currentPdfPage.originalWidth;
+      const pdfPageHeight = currentPdfPage.originalHeight;
+      const elementRatio = elementWidth / elementHeight;
+      const pdfPageRatio = pdfPageWidth / pdfPageHeight;
+      let newDisplaySize: PDFRenderSize;
+      if (pdfPageRatio > elementRatio) {
+        newDisplaySize = {
+          width: elementWidth,
+          height: elementWidth / pdfPageRatio,
+        };
+      } else {
+        newDisplaySize = {
+          width: elementHeight * pdfPageRatio,
+          height: elementHeight,
+        };
+      }
+      const currentDisplaySize = pdfPainterController.getRenderSize();
+      if (
+        newDisplaySize.width !== currentDisplaySize.width ||
+        newDisplaySize.height !== currentDisplaySize.height
+      ) {
+        pdfPainterController.setRenderSize(newDisplaySize);
+      }
+    }
+  }, [pdfPainterController]);
 
-	useEffect(() => {
-		const resizeObserver = new ResizeObserver(() => {
-			updateDisplaySize();
-		});
+  useEffect(() => {
+    const resizeObserver = new ResizeObserver(() => {
+      updateDisplaySize();
+    });
 
-		if (painterElement.current) {
-			resizeObserver.observe(painterElement.current);
-		}
+    if (painterElement.current) {
+      resizeObserver.observe(painterElement.current);
+    }
 
-		return () => {
-			resizeObserver.disconnect();
-		};
-	}, [updateDisplaySize]);
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [updateDisplaySize]);
 
-	return (
-		<div
-			style={{
-				display: "flex",
-				width: "100%",
-				height: "100%",
-				flexDirection: "column",
-			}}
-		>
-			<div
-				ref={painterElement}
-				style={{
-					flex: 1,
-					display: "flex",
-					justifyContent: "center",
-					alignItems: "center",
-					overflow: "hidden",
-				}}
-			>
-				<div
-					style={{
-						position: "relative",
-						width: "fit-content",
-						height: "fit-content",
-					}}
-				>
-					<PDFViewer
-						pdfDocumentURL={pdfDocumentURL}
-						pdfViewerControllerHook={{
-							pdfViewerController: pdfPainterControllerHook.pdfPainterController,
-							onPdfDocumentChange: pdfPainterControllerHook.onPdfDocumentChange,
-							onPdfPageChange: pdfPainterControllerHook.onPdfPageChange,
-							onPdfItemClick: pdfPainterControllerHook.onPdfItemClick,
-							onPdfMouseMoveEvent: pdfPainterControllerHook.onPdfMouseMoveEvent,
-							onPdfWheelEvent: pdfPainterControllerHook.onPdfWheelEvent,
-						}}
-					/>
-					{Children.toArray(children).map((element: ReactNode) => {
-						if (isValidElement(element)) {
-							return (
-								<div
-									key={element.props.instanceId}
-									style={{
-										position: "absolute",
-										top: 0,
-										left: 0,
-										width: pdfPainterController.getRenderSize().width,
-										height: pdfPainterController.getRenderSize().height,
-										pointerEvents: pdfPainterController.getPaintMode() === "draw" ? "unset" : "none",
-									}}
-								>
-									<PainterInstance
-										instanceId={element.props.instanceId}
-										readOnly={element.props.readOnly || pdfPainterController.getPaintMode() !== "draw"}
-										pdfPainterControllerHook={pdfPainterControllerHook}
-										customPdfPainterInstanceControllerHook={element.props.customPdfPainterInstanceControllerHook}
-									/>
-								</div>
-							);
-						}
-						return element;
-					})}
-				</div>
-			</div>
-		</div>
-	);
+  const isInstanceHidden = useCallback(
+    (instanceId:string) => {
+      return (
+        pdfPainterController.getInstanceHidden(instanceId) &&
+        !(pdfPainterController.getPaintMode() === "draw")
+      );
+    },
+    [pdfPainterController]
+  );
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        width: "100%",
+        height: "100%",
+        flexDirection: "column",
+      }}
+    >
+      <div
+        ref={painterElement}
+        style={{
+          flex: 1,
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            position: "relative",
+            width: "fit-content",
+            height: "fit-content",
+          }}
+        >
+          <PDFViewer
+            pdfDocumentURL={pdfDocumentURL}
+            pdfViewerControllerHook={{
+              pdfViewerController:
+                pdfPainterControllerHook.pdfPainterController,
+              onPdfDocumentChange: pdfPainterControllerHook.onPdfDocumentChange,
+              onPdfPageChange: pdfPainterControllerHook.onPdfPageChange,
+              onPdfItemClick: pdfPainterControllerHook.onPdfItemClick,
+              onPdfMouseMoveEvent: pdfPainterControllerHook.onPdfMouseMoveEvent,
+              onPdfWheelEvent: pdfPainterControllerHook.onPdfWheelEvent,
+            }}
+          />
+          {Children.toArray(children).map((element: ReactNode) => {
+            if (isValidElement(element)) {
+              return (
+                <div
+                  key={element.props.instanceId}
+                  style={{
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    width: pdfPainterController.getRenderSize().width,
+                    height: pdfPainterController.getRenderSize().height,
+                    pointerEvents:
+                      pdfPainterController.getPaintMode() === "draw"
+                        ? "unset"
+                        : "none",
+                    visibility: isInstanceHidden(element.props.instanceId) ? "hidden" : undefined
+                  }}
+                >
+                  <PainterInstance
+                    instanceId={element.props.instanceId}
+                    readOnly={
+                      element.props.readOnly ||
+                      pdfPainterController.getPaintMode() !== "draw"
+                    }
+                    pdfPainterControllerHook={pdfPainterControllerHook}
+                    customPdfPainterInstanceControllerHook={
+                      element.props.customPdfPainterInstanceControllerHook
+                    }
+                  />
+                </div>
+              );
+            }
+            return element;
+          })}
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export const PDFPainter = memo(PDFPainterComponent);

--- a/packages/front-end/PaintPDF/components/PDFPainter/PDFPainter.tsx
+++ b/packages/front-end/PaintPDF/components/PDFPainter/PDFPainter.tsx
@@ -82,10 +82,13 @@ const PDFPainterComponent = ({
   }, [updateDisplaySize]);
 
   const isInstanceHidden = useCallback(
-    (instanceId:string) => {
+    (instanceId: string) => {
       return (
         pdfPainterController.getInstanceHidden(instanceId) &&
-        !(pdfPainterController.getPaintMode() === "draw")
+        !(
+          pdfPainterController.getPaintMode() === "draw" &&
+          pdfPainterController.isIdEnsureVisibleWhileDraw(instanceId)
+        )
       );
     },
     [pdfPainterController]
@@ -144,7 +147,9 @@ const PDFPainterComponent = ({
                       pdfPainterController.getPaintMode() === "draw"
                         ? "unset"
                         : "none",
-                    visibility: isInstanceHidden(element.props.instanceId) ? "hidden" : undefined
+                    visibility: isInstanceHidden(element.props.instanceId)
+                      ? "hidden"
+                      : undefined,
                   }}
                 >
                   <PainterInstance

--- a/packages/front-end/PaintPDF/components/PDFPainter/PDFPainterControlBar.tsx
+++ b/packages/front-end/PaintPDF/components/PDFPainter/PDFPainterControlBar.tsx
@@ -7,6 +7,7 @@ import ArrowLeftIcon from "@/PaintPDF/assets/icons/arrow-left.svg";
 import ArrowRightIcon from "@/PaintPDF/assets/icons/arrow-right.svg";
 import { PDFPainterControlBarButton } from "@/PaintPDF/components";
 import { css } from "@/styled-system/css";
+import { ModeContainer } from "@/app/view/[sessionId]/_components/Mode";
 
 const PDFPainterControlBarComponent = ({
   pdfPainterController,
@@ -82,25 +83,10 @@ const PDFPainterControlBarComponent = ({
           <p>{showToolTip ? "닫기" : "모드"}</p>
         </PDFPainterControlBarButton>
         {showToolTip && (
-          <div
-            className={css({
-              position: "absolute",
-              bottom: "100%",
-              left:0,
-              backgroundColor: "#fff",
-              border: "2px solid black",
-              borderRadius: "0.5rem",
-              padding: "1rem",
-              color:"#000",
-              whiteSpace: "normal",
-              zIndex:1000,
-              width:"15rem"
-            })}
-          >
+          <ModeContainer setVisible={setShowToolTip}>
             {modeComponent}
-          </div>
+          </ModeContainer>
         )}
-        
       </div>
     </div>
   );

--- a/packages/front-end/PaintPDF/components/PDFPainter/PDFPainterControlBar.tsx
+++ b/packages/front-end/PaintPDF/components/PDFPainter/PDFPainterControlBar.tsx
@@ -25,7 +25,7 @@ const PDFPainterControlBarComponent = ({
 
   return (
     <div
-      style={{
+      className={css({
         display: "flex",
         padding: "1em",
         color: "#ffffff",
@@ -34,7 +34,7 @@ const PDFPainterControlBarComponent = ({
         alignItems: "center",
         gap: "1em",
         height: "4em",
-      }}
+      })}
     >
       <PDFPainterControlBarButton
         onClick={() => pdfPainterController.setPaintMode("default")}
@@ -86,15 +86,21 @@ const PDFPainterControlBarComponent = ({
             className={css({
               position: "absolute",
               bottom: "100%",
+              left:0,
               backgroundColor: "#fff",
               border: "2px solid black",
               borderRadius: "0.5rem",
               padding: "1rem",
+              color:"#000",
+              whiteSpace: "normal",
+              zIndex:1000,
+              width:"15rem"
             })}
           >
             {modeComponent}
           </div>
         )}
+        
       </div>
     </div>
   );

--- a/packages/front-end/PaintPDF/components/PDFPainter/PDFPainterControlBar.tsx
+++ b/packages/front-end/PaintPDF/components/PDFPainter/PDFPainterControlBar.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect } from "react";
+import { memo, ReactNode, useEffect, useState } from "react";
 import type { PDFPainterController } from "./types";
 import ToolPointerIcon from "@/PaintPDF/assets/icons/tool-pointer.svg";
 import ToolHandIcon from "@/PaintPDF/assets/icons/tool-hand.svg";
@@ -6,17 +6,22 @@ import ToolEditIcon from "@/PaintPDF/assets/icons/tool-edit.svg";
 import ArrowLeftIcon from "@/PaintPDF/assets/icons/arrow-left.svg";
 import ArrowRightIcon from "@/PaintPDF/assets/icons/arrow-right.svg";
 import { PDFPainterControlBarButton } from "@/PaintPDF/components";
+import { css } from "@/styled-system/css";
 
 const PDFPainterControlBarComponent = ({
   pdfPainterController,
+  modeComponent,
 }: {
   pdfPainterController: PDFPainterController;
+  modeComponent?: ReactNode;
 }) => {
   useEffect(() => {
     pdfPainterController.setDragModeEnabled(
-      pdfPainterController.getPaintMode() === "move",
+      pdfPainterController.getPaintMode() === "move"
     );
   }, [pdfPainterController]);
+
+  const [showToolTip, setShowToolTip] = useState(false);
 
   return (
     <div
@@ -28,7 +33,7 @@ const PDFPainterControlBarComponent = ({
         justifyContent: "center",
         alignItems: "center",
         gap: "1em",
-        height:"4em",
+        height: "4em",
       }}
     >
       <PDFPainterControlBarButton
@@ -68,6 +73,29 @@ const PDFPainterControlBarComponent = ({
       >
         <ArrowRightIcon width={"1.6em"} height={"1.6em"} />
       </PDFPainterControlBarButton>
+      <div className={css({ position: "relative" })}>
+        <PDFPainterControlBarButton
+          onClick={() => {
+            setShowToolTip(!showToolTip);
+          }}
+        >
+          <p>{showToolTip ? "닫기" : "모드"}</p>
+        </PDFPainterControlBarButton>
+        {showToolTip && (
+          <div
+            className={css({
+              position: "absolute",
+              bottom: "100%",
+              backgroundColor: "#fff",
+              border: "2px solid black",
+              borderRadius: "0.5rem",
+              padding: "1rem",
+            })}
+          >
+            {modeComponent}
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/packages/front-end/PaintPDF/components/PDFPainter/PDFPainterControlBar.tsx
+++ b/packages/front-end/PaintPDF/components/PDFPainter/PDFPainterControlBar.tsx
@@ -28,6 +28,7 @@ const PDFPainterControlBarComponent = ({
         justifyContent: "center",
         alignItems: "center",
         gap: "1em",
+        height:"4em",
       }}
     >
       <PDFPainterControlBarButton

--- a/packages/front-end/PaintPDF/components/PDFPainter/PDFPainterControlBarButton.tsx
+++ b/packages/front-end/PaintPDF/components/PDFPainter/PDFPainterControlBarButton.tsx
@@ -15,7 +15,8 @@ const PDFPainterControlBarButtonComponent = ({
         padding: "0.4em 0.8em",
         userSelect: "none",
         color: "#000000",
-        backgroundColor: "#ffffff",
+        backgroundColor: disabled? "#d8d8d8" : "#ffffff",
+        cursor:disabled? "default":"pointer",
       }}
       onClick={onClick}
       disabled={disabled}

--- a/packages/front-end/PaintPDF/components/PDFPainter/PDFPainterControlBarButton.tsx
+++ b/packages/front-end/PaintPDF/components/PDFPainter/PDFPainterControlBarButton.tsx
@@ -1,31 +1,20 @@
-import { memo, ReactNode } from "react";
+import { styled } from "@/styled-system/jsx";
+import { memo } from "react";
 
-const PDFPainterControlBarButtonComponent = ({
-  onClick,
-  disabled,
-  children,
-}: {
-  onClick?: () => void;
-  disabled?: boolean;
-  children: ReactNode;
-}) => {
-  return (
-    <button
-      style={{
-        padding: "0.4em 0.8em",
-        userSelect: "none",
-        color: "#000000",
-        backgroundColor: disabled? "#d8d8d8" : "#ffffff",
-        cursor:disabled? "default":"pointer",
-      }}
-      onClick={onClick}
-      disabled={disabled}
-    >
-      {children}
-    </button>
-  );
-};
+const PDFPainterControlBarButtonComponent = styled("button", {
+  base: {
+    padding: "0.4em 0.8em",
+    userSelect: "none",
+    color: "#000000",
+    backgroundColor: "#ffffff",
+    cursor: "pointer",
+    _disabled: {
+      backgroundColor: "#d8d8d8",
+      cursor: "default",
+    },
+  },
+});
 
 export const PDFPainterControlBarButton = memo(
-  PDFPainterControlBarButtonComponent,
+  PDFPainterControlBarButtonComponent
 );

--- a/packages/front-end/PaintPDF/components/PDFPainter/hooks/usePDFPainterController.ts
+++ b/packages/front-end/PaintPDF/components/PDFPainter/hooks/usePDFPainterController.ts
@@ -288,6 +288,20 @@ export const usePDFPainterController = ({
     [isInstanceHidden]
   );
 
+  const ensureVisibleWhileDrawRef = useRef<Set<string>>(new Set());
+
+  const isIdEnsureVisibleWhileDraw = useCallback((editorId: string) => {
+    return ensureVisibleWhileDrawRef.current.has(editorId);
+  }, []);
+
+  const addIdEnsureVisibleWhileDraw = useCallback((editorId: string) => {
+    ensureVisibleWhileDrawRef.current.add(editorId);
+  }, []);
+
+  const deleteIdEnsureVisibleWhileDraw = useCallback((editorId: string) => {
+    ensureVisibleWhileDrawRef.current.delete(editorId);
+  }, []);
+
   const pdfPainterController: PDFPainterController = useMemo(() => {
     return {
       ...pdfViewerController,
@@ -305,6 +319,9 @@ export const usePDFPainterController = ({
       clearEditorSnapshot: clearEditorSnapshot,
       getInstanceHidden,
       setInstanceHidden,
+      isIdEnsureVisibleWhileDraw,
+      addIdEnsureVisibleWhileDraw,
+      deleteIdEnsureVisibleWhileDraw,
     };
   }, [
     pdfViewerController,
@@ -316,6 +333,9 @@ export const usePDFPainterController = ({
     clearEditorSnapshot,
     getInstanceHidden,
     setInstanceHidden,
+    isIdEnsureVisibleWhileDraw,
+    addIdEnsureVisibleWhileDraw,
+    deleteIdEnsureVisibleWhileDraw,
     paintMode,
   ]);
 

--- a/packages/front-end/PaintPDF/components/PDFPainter/hooks/usePDFPainterController.ts
+++ b/packages/front-end/PaintPDF/components/PDFPainter/hooks/usePDFPainterController.ts
@@ -30,6 +30,10 @@ export const usePDFPainterController = ({
 
   const [paintMode, setPaintMode] = useState<PaintMode>("default");
 
+  const [isInstanceHidden, setIsInstanceHidden] = useState<{
+    [key: string]: boolean;
+  }>({});
+
   const editors = useRef<{ [editorId: string]: Editor }>({});
 
   const currentPageId = useRef<number | null>(null);
@@ -270,6 +274,20 @@ export const usePDFPainterController = ({
     [loadEditorSnapshot, clearEditorSnapshotFromStorage]
   );
 
+  const getInstanceHidden = useCallback(
+    (editorId: string) => {
+      return !!isInstanceHidden[editorId];
+    },
+    [isInstanceHidden]
+  );
+
+  const setInstanceHidden = useCallback(
+    (editorId: string, isHidden: boolean = !isInstanceHidden) => {
+      setIsInstanceHidden({ ...isInstanceHidden, editorId: isHidden });
+    },
+    [isInstanceHidden]
+  );
+
   const pdfPainterController: PDFPainterController = useMemo(() => {
     return {
       ...pdfViewerController,
@@ -285,17 +303,10 @@ export const usePDFPainterController = ({
       getEditorSnapshot: getEditorSnapshot,
       setEditorSnapshot: setEditorSnapshot,
       clearEditorSnapshot: clearEditorSnapshot,
+      getInstanceHidden,
+      setInstanceHidden
     };
-  }, [
-    pdfViewerController,
-    paintMode,
-    registerEditor,
-    unregisterEditor,
-    getEditor,
-    getEditorSnapshot,
-    setEditorSnapshot,
-    clearEditorSnapshot,
-  ]);
+  }, [pdfViewerController, registerEditor, unregisterEditor, getEditor, getEditorSnapshot, setEditorSnapshot, clearEditorSnapshot, getInstanceHidden, setInstanceHidden, paintMode]);
 
   return {
     pdfPainterController: pdfPainterController,

--- a/packages/front-end/PaintPDF/components/PDFPainter/hooks/usePDFPainterController.ts
+++ b/packages/front-end/PaintPDF/components/PDFPainter/hooks/usePDFPainterController.ts
@@ -276,7 +276,6 @@ export const usePDFPainterController = ({
 
   const getInstanceHidden = useCallback(
     (editorId: string) => {
-      console.log(isInstanceHidden)
       return !!isInstanceHidden[editorId];
     },
     [isInstanceHidden]

--- a/packages/front-end/PaintPDF/components/PDFPainter/hooks/usePDFPainterController.ts
+++ b/packages/front-end/PaintPDF/components/PDFPainter/hooks/usePDFPainterController.ts
@@ -276,14 +276,15 @@ export const usePDFPainterController = ({
 
   const getInstanceHidden = useCallback(
     (editorId: string) => {
+      console.log(isInstanceHidden)
       return !!isInstanceHidden[editorId];
     },
     [isInstanceHidden]
   );
 
   const setInstanceHidden = useCallback(
-    (editorId: string, isHidden: boolean = !isInstanceHidden) => {
-      setIsInstanceHidden({ ...isInstanceHidden, editorId: isHidden });
+    (editorId: string, isHidden: boolean) => {
+      setIsInstanceHidden({ ...isInstanceHidden, [editorId]: isHidden });
     },
     [isInstanceHidden]
   );
@@ -304,9 +305,20 @@ export const usePDFPainterController = ({
       setEditorSnapshot: setEditorSnapshot,
       clearEditorSnapshot: clearEditorSnapshot,
       getInstanceHidden,
-      setInstanceHidden
+      setInstanceHidden,
     };
-  }, [pdfViewerController, registerEditor, unregisterEditor, getEditor, getEditorSnapshot, setEditorSnapshot, clearEditorSnapshot, getInstanceHidden, setInstanceHidden, paintMode]);
+  }, [
+    pdfViewerController,
+    registerEditor,
+    unregisterEditor,
+    getEditor,
+    getEditorSnapshot,
+    setEditorSnapshot,
+    clearEditorSnapshot,
+    getInstanceHidden,
+    setInstanceHidden,
+    paintMode,
+  ]);
 
   return {
     pdfPainterController: pdfPainterController,

--- a/packages/front-end/PaintPDF/components/PDFPainter/types/index.ts
+++ b/packages/front-end/PaintPDF/components/PDFPainter/types/index.ts
@@ -2,6 +2,7 @@ import { Editor, TLEditorSnapshot, IdOf, TLRecord } from "tldraw";
 
 import { PDFDocument, PDFItemClickHandlerArguments, PDFPage, PDFViewerController } from "../../PDF/types";
 import { ExternalAssetStore } from "../../Painter/types";
+import { lcov } from "node:test/reporters";
 
 export type PaintMode = "default" | "move" | "draw";
 
@@ -22,6 +23,9 @@ export type PDFPainterController = {
 	clearEditorSnapshot: (editorId: string, pageIndex: number) => void;
 	getInstanceHidden: (editorId:string) => boolean;
 	setInstanceHidden:(editorId:string,isHidden:boolean) => void;
+	isIdEnsureVisibleWhileDraw:(editorId: string) => boolean;
+	addIdEnsureVisibleWhileDraw:(editorId: string) => void;
+	deleteIdEnsureVisibleWhileDraw:(editorId: string) => void;
 } & PDFViewerController;
 
 export type PDFPainterControllerHook = {

--- a/packages/front-end/PaintPDF/components/PDFPainter/types/index.ts
+++ b/packages/front-end/PaintPDF/components/PDFPainter/types/index.ts
@@ -20,6 +20,8 @@ export type PDFPainterController = {
 	getEditorSnapshot: (editorId: string, pageIndex: number) => EditorSnapshot | null;
 	setEditorSnapshot: (editorId: string, pageIndex: number, snapshot: EditorSnapshot) => void;
 	clearEditorSnapshot: (editorId: string, pageIndex: number) => void;
+	getInstanceHidden: (editorId:string) => boolean;
+	setInstanceHidden:(editorId:string,isHidden:boolean) => void;
 } & PDFViewerController;
 
 export type PDFPainterControllerHook = {

--- a/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
@@ -4,6 +4,7 @@ import { useHostSocket } from "../_hooks/useHostSocket";
 import {
   PainterInstanceGenerator,
   PDFPainter,
+  PDFPainterControlBar,
   usePDFPainterController,
   usePDFPainterInstanceController,
 } from "@/PaintPDF/components";
@@ -30,44 +31,49 @@ export default function HostViewer(props: ViewerPropType) {
   );
 
   return (
-    <div
-      className={css({
-        display: "flex",
-        width: "100vw",
-        height: "100vh",
-      })}
-    >
-      <PreviewPages
-        pdfDocumentURL={pdfDocument.url}
-        PDFPainterController={pdfPainterControllerHook.pdfPainterController}
-        getBadgeVisible={(index) => roomPageViewerCount.hasOwnProperty(index)}
-        getBadgeContent={(index) => {
-          return <>{index !== undefined && roomPageViewerCount[index]}</>;
-        }}
-      />
+    <>
       <div
         className={css({
-          justifyContent: "center",
-          alignItems: "center",
-          width: `calc(100% - 13rem)`,
-          height: "100%",
           display: "flex",
+          width: "100vw",
+          height: "calc(100vh - 3.6em)",
         })}
       >
-        <PDFPainter
-          painterId={`${sessionId}_${pdfDocument.fileId}`}
+        <PreviewPages
           pdfDocumentURL={pdfDocument.url}
-          customPdfPainterControllerHook={pdfPainterControllerHook}
+          PDFPainterController={pdfPainterControllerHook.pdfPainterController}
+          getBadgeVisible={(index) => roomPageViewerCount.hasOwnProperty(index)}
+          getBadgeContent={(index) => {
+            return <>{index !== undefined && roomPageViewerCount[index]}</>;
+          }}
+        />
+        <div
+          className={css({
+            justifyContent: "center",
+            alignItems: "center",
+            width: `calc(100% - 13rem)`,
+            height: "100%",
+            display: "flex",
+          })}
         >
-          <PainterInstanceGenerator
-            instanceId={"Host"}
-            readOnly={false}
-            customPdfPainterInstanceControllerHook={
-              pdfPainterHostInstanceControllerHook
-            }
-          />
-        </PDFPainter>
+          <PDFPainter
+            painterId={`${sessionId}_${pdfDocument.fileId}`}
+            pdfDocumentURL={pdfDocument.url}
+            customPdfPainterControllerHook={pdfPainterControllerHook}
+          >
+            <PainterInstanceGenerator
+              instanceId={"Host"}
+              readOnly={false}
+              customPdfPainterInstanceControllerHook={
+                pdfPainterHostInstanceControllerHook
+              }
+            />
+          </PDFPainter>
+        </div>
       </div>
-    </div>
+      <PDFPainterControlBar
+        pdfPainterController={pdfPainterControllerHook.pdfPainterController}
+      />
+    </>
   );
 }

--- a/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
@@ -11,6 +11,8 @@ import {
 import { ViewerPropType } from "../_types/ViewerType";
 import { PreviewPages } from "./PreviewPages";
 import { css } from "@/styled-system/css";
+import { ModeControl } from "./Mode";
+import { useState } from "react";
 
 export default function HostViewer(props: ViewerPropType) {
   const { fileList, sessionId } = props;
@@ -19,6 +21,7 @@ export default function HostViewer(props: ViewerPropType) {
   const pdfPainterControllerHook = usePDFPainterController({
     painterId: `${sessionId}_${pdfDocument.fileId}`,
   });
+  const [isHideMyDraw, setIsHideMyDraw] = useState(false);
   const pdfPainterHostInstanceControllerHook = usePDFPainterInstanceController({
     editorId: "Host",
     pdfPainterController: pdfPainterControllerHook.pdfPainterController,
@@ -73,6 +76,18 @@ export default function HostViewer(props: ViewerPropType) {
       </div>
       <PDFPainterControlBar
         pdfPainterController={pdfPainterControllerHook.pdfPainterController}
+        modeComponent={
+          <>
+            <ModeControl
+              labelText="내 필기 가리기"
+              id="hide-host-draw"
+              checked={isHideMyDraw}
+              onChange={(e) => {
+                setIsHideMyDraw(e.target.checked);
+              }}
+            />
+          </>
+        }
       />
     </>
   );

--- a/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
@@ -81,9 +81,14 @@ export default function HostViewer(props: ViewerPropType) {
             <ModeControl
               labelText="내 필기 가리기"
               id="hide-host-draw"
-              checked={isHideMyDraw}
+              checked={pdfPainterControllerHook.pdfPainterController.getInstanceHidden(
+                "Host"
+              )}
               onChange={(e) => {
-                setIsHideMyDraw(e.target.checked);
+                pdfPainterControllerHook.pdfPainterController.setInstanceHidden(
+                  "Host",
+                  e.target.checked
+                );
               }}
             />
           </>

--- a/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
@@ -12,6 +12,7 @@ import { ViewerPropType } from "../_types/ViewerType";
 import { PreviewPages } from "./PreviewPages";
 import { css } from "@/styled-system/css";
 import { ModeControl } from "./Mode";
+import { useEnsureVisibleWhileDraw } from "../_hooks/useEnsureVisibleWhileDraw";
 
 export default function HostViewer(props: ViewerPropType) {
   const { fileList, sessionId } = props;
@@ -32,6 +33,7 @@ export default function HostViewer(props: ViewerPropType) {
     pdfPainterInstanceController,
     pdfPainterController
   );
+  useEnsureVisibleWhileDraw("Host",pdfPainterController)
 
   return (
     <>

--- a/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
@@ -36,7 +36,7 @@ export default function HostViewer(props: ViewerPropType) {
         className={css({
           display: "flex",
           width: "100vw",
-          height: "calc(100vh - 3.6em)",
+          height: "calc(100vh - 4em)",
         })}
       >
         <PreviewPages

--- a/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/HostViewer.tsx
@@ -12,7 +12,6 @@ import { ViewerPropType } from "../_types/ViewerType";
 import { PreviewPages } from "./PreviewPages";
 import { css } from "@/styled-system/css";
 import { ModeControl } from "./Mode";
-import { useState } from "react";
 
 export default function HostViewer(props: ViewerPropType) {
   const { fileList, sessionId } = props;
@@ -21,16 +20,17 @@ export default function HostViewer(props: ViewerPropType) {
   const pdfPainterControllerHook = usePDFPainterController({
     painterId: `${sessionId}_${pdfDocument.fileId}`,
   });
-  const [isHideMyDraw, setIsHideMyDraw] = useState(false);
   const pdfPainterHostInstanceControllerHook = usePDFPainterInstanceController({
     editorId: "Host",
     pdfPainterController: pdfPainterControllerHook.pdfPainterController,
   });
+  const { pdfPainterController } = pdfPainterControllerHook;
+  const { pdfPainterInstanceController } = pdfPainterHostInstanceControllerHook;
   const { roomPageViewerCount } = useHostSocket(
     sessionId,
     fileId,
-    pdfPainterHostInstanceControllerHook.pdfPainterInstanceController,
-    pdfPainterControllerHook.pdfPainterController
+    pdfPainterInstanceController,
+    pdfPainterController
   );
 
   return (
@@ -44,7 +44,7 @@ export default function HostViewer(props: ViewerPropType) {
       >
         <PreviewPages
           pdfDocumentURL={pdfDocument.url}
-          PDFPainterController={pdfPainterControllerHook.pdfPainterController}
+          PDFPainterController={pdfPainterController}
           getBadgeVisible={(index) => roomPageViewerCount.hasOwnProperty(index)}
           getBadgeContent={(index) => {
             return <>{index !== undefined && roomPageViewerCount[index]}</>;
@@ -75,17 +75,17 @@ export default function HostViewer(props: ViewerPropType) {
         </div>
       </div>
       <PDFPainterControlBar
-        pdfPainterController={pdfPainterControllerHook.pdfPainterController}
+        pdfPainterController={pdfPainterController}
         modeComponent={
           <>
             <ModeControl
               labelText="내 필기 가리기"
               id="hide-host-draw"
-              checked={pdfPainterControllerHook.pdfPainterController.getInstanceHidden(
+              checked={pdfPainterController.getInstanceHidden(
                 "Host"
               )}
               onChange={(e) => {
-                pdfPainterControllerHook.pdfPainterController.setInstanceHidden(
+                pdfPainterController.setInstanceHidden(
                   "Host",
                   e.target.checked
                 );

--- a/packages/front-end/app/view/[sessionId]/_components/Mode.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/Mode.tsx
@@ -1,0 +1,97 @@
+import { css, cx } from "@/styled-system/css";
+import {
+  DetailedHTMLProps,
+  Dispatch,
+  InputHTMLAttributes,
+  ReactNode,
+  SetStateAction,
+  useEffect,
+} from "react";
+
+export function ModeControl({
+  labelText,
+  ...attr
+}: DetailedHTMLProps<
+  InputHTMLAttributes<HTMLInputElement>,
+  HTMLInputElement
+> & { labelText: string }) {
+  return (
+    <div>
+      <input
+        type="checkbox"
+        onChange={() => {
+          alert("아직 미구현된 기능입니다.");
+        }}
+        {...attr}
+        className={cx(
+          css({ margin: "0.5rem 0.25rem 0.5rem 0" }),
+          attr.className
+        )}
+      />
+      <label htmlFor={attr.id}>{labelText}</label>
+    </div>
+  );
+}
+
+export function ModeContainer({
+  setVisible,
+  children,
+}: {
+  setVisible: Dispatch<SetStateAction<boolean>>;
+  children: ReactNode;
+}) {
+  useEffect(() => {
+    const handleEscKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape" || event.key === "Esc") {
+        setVisible(false);
+      }
+    };
+
+    // 키보드 이벤트 리스너 등록
+    window.addEventListener("keydown", handleEscKey);
+
+    // 컴포넌트가 언마운트될 때 이벤트 리스너 제거
+    return () => {
+      window.removeEventListener("keydown", handleEscKey);
+    };
+  }, []);
+  return (
+    <div
+      className={css({
+        position: "absolute",
+        bottom: "100%",
+        left: 0,
+        backgroundColor: "#fff",
+        border: "2px solid black",
+        borderRadius: "0.5rem",
+        padding: "1rem",
+        color: "#000",
+        whiteSpace: "normal",
+        zIndex: 1000,
+        width: "15rem",
+      })}
+    >
+      <div
+        className={css({
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "0.5rem 0",
+        })}
+      >
+        <p>
+          모드 설정
+        </p>
+        <button
+          onClick={() => {
+            setVisible(false);
+          }}
+          className={css({ cursor: "pointer" })}
+        >
+          X
+        </button>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/packages/front-end/app/view/[sessionId]/_components/Mode.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/Mode.tsx
@@ -47,14 +47,12 @@ export function ModeContainer({
       }
     };
 
-    // 키보드 이벤트 리스너 등록
     window.addEventListener("keydown", handleEscKey);
 
-    // 컴포넌트가 언마운트될 때 이벤트 리스너 제거
     return () => {
       window.removeEventListener("keydown", handleEscKey);
     };
-  }, []);
+  }, [setVisible]);
   return (
     <div
       className={css({

--- a/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
@@ -16,6 +16,7 @@ import { css } from "@/styled-system/css";
 import { PreviewPages } from "./PreviewPages";
 import { useState } from "react";
 import { ModeControl } from "./Mode";
+import { useEnsureVisibleWhileDraw } from "../_hooks/useEnsureVisibleWhileDraw";
 
 export default function ParticipantViewer(props: ViewerPropType) {
   const { fileList, sessionId } = props;
@@ -48,6 +49,7 @@ export default function ParticipantViewer(props: ViewerPropType) {
     pdfPainterControllerHook.pdfPainterController,
     isChaseMode
   );
+  useEnsureVisibleWhileDraw("Participant",pdfPainterController)
 
   if (joinQuery.isLoading) {
     return <p>로딩...</p>;

--- a/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
@@ -15,6 +15,7 @@ import { ViewerPropType } from "../_types/ViewerType";
 import { css } from "@/styled-system/css";
 import { PreviewPages } from "./PreviewPages";
 import { useState } from "react";
+import { ModeControl } from "./Mode";
 
 export default function ParticipantViewer(props: ViewerPropType) {
   const { fileList, sessionId } = props;
@@ -106,18 +107,22 @@ export default function ParticipantViewer(props: ViewerPropType) {
         pdfPainterController={pdfPainterControllerHook.pdfPainterController}
         modeComponent={
           <>
-            <div>
-              <input
-                type="checkbox"
-                id="chase-host"
-                className={css({ margin: "0.25rem" })}
-                checked={isChaseMode}
-                onChange={(e) => {
-                  setIsChaseMode(e.target.checked);
-                }}
-              />
-              <label htmlFor="chase-host">호스트 시점 따라가기</label>
-            </div>
+            <ModeControl
+              labelText="호스트 시점 따라가기"
+              id="chase-host"
+              checked={isChaseMode}
+              onChange={(e) => {
+                setIsChaseMode(e.target.checked);
+              }}
+            />
+            <ModeControl
+              labelText="내 필기 가리기"
+              id="hide-host-draw"
+            />
+            <ModeControl
+              labelText="호스트 필기 가리기"
+              id="hide-my-draw"
+            />
           </>
         }
       />

--- a/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
@@ -57,7 +57,7 @@ export default function ParticipantViewer(props: ViewerPropType) {
         className={css({
           display: "flex",
           width: "100vw",
-          height: "calc(100vh - 3.6em)",
+          height: "calc(100vh - 4em)",
         })}
       >
 

--- a/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
@@ -14,6 +14,7 @@ import {
 import { ViewerPropType } from "../_types/ViewerType";
 import { css } from "@/styled-system/css";
 import { PreviewPages } from "./PreviewPages";
+import { useState } from "react";
 
 export default function ParticipantViewer(props: ViewerPropType) {
   const { fileList, sessionId } = props;
@@ -25,6 +26,7 @@ export default function ParticipantViewer(props: ViewerPropType) {
       return await apiClient.post(`/user/session/${sessionId}/join`);
     },
   });
+  const [isChaseMode, setIsChaseMode] = useState(false);
   const pdfPainterControllerHook = usePDFPainterController({
     painterId: `${sessionId}_${pdfDocument.fileId}`,
   });
@@ -41,7 +43,8 @@ export default function ParticipantViewer(props: ViewerPropType) {
     sessionId,
     fileId,
     pdfPainterHostInstanceControllerHook.pdfPainterInstanceController,
-    pdfPainterControllerHook.pdfPainterController
+    pdfPainterControllerHook.pdfPainterController,
+    isChaseMode
   );
 
   if (joinQuery.isLoading) {
@@ -104,7 +107,15 @@ export default function ParticipantViewer(props: ViewerPropType) {
         modeComponent={
           <>
             <div>
-              <input type="checkbox" id="chase-host" />
+              <input
+                type="checkbox"
+                id="chase-host"
+                className={css({ margin: "0.25rem" })}
+                checked={isChaseMode}
+                onChange={(e) => {
+                  setIsChaseMode(e.target.checked);
+                }}
+              />
               <label htmlFor="chase-host">호스트 시점 따라가기</label>
             </div>
           </>

--- a/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
@@ -60,48 +60,55 @@ export default function ParticipantViewer(props: ViewerPropType) {
           height: "calc(100vh - 4em)",
         })}
       >
-
-          <PreviewPages
+        <PreviewPages
+          pdfDocumentURL={pdfDocument.url}
+          PDFPainterController={pdfPainterControllerHook.pdfPainterController}
+          getBadgeVisible={(index) => index === hostIndex}
+          getBadgeContent={(index) => {
+            return <>{index !== undefined && hostIndex !== null && "!"}</>;
+          }}
+        />
+        <div
+          className={css({
+            justifyContent: "center",
+            alignItems: "center",
+            width: `calc(100% - 13rem)`,
+            height: "100%",
+            display: "flex",
+          })}
+        >
+          <PDFPainter
+            painterId={`${sessionId}_${pdfDocument.fileId}`}
             pdfDocumentURL={pdfDocument.url}
-            PDFPainterController={pdfPainterControllerHook.pdfPainterController}
-            getBadgeVisible={(index) => index === hostIndex}
-            getBadgeContent={(index) => {
-              return <>{index !== undefined && hostIndex !== null && "!"}</>;
-            }}
-          />
-          <div
-            className={css({
-              justifyContent: "center",
-              alignItems: "center",
-              width: `calc(100% - 13rem)`,
-              height: "100%",
-              display: "flex",
-            })}
+            customPdfPainterControllerHook={pdfPainterControllerHook}
           >
-            <PDFPainter
-              painterId={`${sessionId}_${pdfDocument.fileId}`}
-              pdfDocumentURL={pdfDocument.url}
-              customPdfPainterControllerHook={pdfPainterControllerHook}
-            >
-              <PainterInstanceGenerator
-                instanceId={"Host"}
-                readOnly={true}
-                customPdfPainterInstanceControllerHook={
-                  pdfPainterHostInstanceControllerHook
-                }
-              />
-              <PainterInstanceGenerator
-                instanceId={"Participant"}
-                readOnly={false}
-                customPdfPainterInstanceControllerHook={
-                  pdfPainterParticipantInstanceControllerHook
-                }
-              />
-            </PDFPainter>
-          </div>
+            <PainterInstanceGenerator
+              instanceId={"Host"}
+              readOnly={true}
+              customPdfPainterInstanceControllerHook={
+                pdfPainterHostInstanceControllerHook
+              }
+            />
+            <PainterInstanceGenerator
+              instanceId={"Participant"}
+              readOnly={false}
+              customPdfPainterInstanceControllerHook={
+                pdfPainterParticipantInstanceControllerHook
+              }
+            />
+          </PDFPainter>
         </div>
+      </div>
       <PDFPainterControlBar
         pdfPainterController={pdfPainterControllerHook.pdfPainterController}
+        modeComponent={
+          <>
+            <div>
+              <input type="checkbox" id="chase-host" />
+              <label htmlFor="chase-host">호스트 시점 따라가기</label>
+            </div>
+          </>
+        }
       />
     </>
   );

--- a/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
@@ -113,6 +113,7 @@ export default function ParticipantViewer(props: ViewerPropType) {
                 className={css({ margin: "0.25rem" })}
                 checked={isChaseMode}
                 onChange={(e) => {
+                  console.log("hello")
                   setIsChaseMode(e.target.checked);
                 }}
               />

--- a/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
@@ -7,6 +7,7 @@ import { useParticipantSocket } from "../_hooks/useParticipantSocket";
 import {
   PainterInstanceGenerator,
   PDFPainter,
+  PDFPainterControlBar,
   usePDFPainterController,
   usePDFPainterInstanceController,
 } from "@/PaintPDF/components";
@@ -51,51 +52,57 @@ export default function ParticipantViewer(props: ViewerPropType) {
   }
 
   return (
-    <div
-      className={css({
-        display: "flex",
-        width: "100vw",
-        height: "100vh",
-      })}
-    >
-      <PreviewPages
-        pdfDocumentURL={pdfDocument.url}
-        PDFPainterController={pdfPainterControllerHook.pdfPainterController}
-        getBadgeVisible={(index) => index === hostIndex}
-        getBadgeContent={(index) => {
-          return <>{index !== undefined && hostIndex !== null && "!"}</>;
-        }}
-      />
+    <>
       <div
         className={css({
-          justifyContent: "center",
-          alignItems: "center",
-          width: `calc(100% - 13rem)`,
-          height: "100%",
           display: "flex",
+          width: "100vw",
+          height: "calc(100vh - 3.6em)",
         })}
       >
-        <PDFPainter
-          painterId={`${sessionId}_${pdfDocument.fileId}`}
-          pdfDocumentURL={pdfDocument.url}
-          customPdfPainterControllerHook={pdfPainterControllerHook}
-        >
-          <PainterInstanceGenerator
-            instanceId={"Host"}
-            readOnly={true}
-            customPdfPainterInstanceControllerHook={
-              pdfPainterHostInstanceControllerHook
-            }
+
+          <PreviewPages
+            pdfDocumentURL={pdfDocument.url}
+            PDFPainterController={pdfPainterControllerHook.pdfPainterController}
+            getBadgeVisible={(index) => index === hostIndex}
+            getBadgeContent={(index) => {
+              return <>{index !== undefined && hostIndex !== null && "!"}</>;
+            }}
           />
-          <PainterInstanceGenerator
-            instanceId={"Participant"}
-            readOnly={false}
-            customPdfPainterInstanceControllerHook={
-              pdfPainterParticipantInstanceControllerHook
-            }
-          />
-        </PDFPainter>
-      </div>
-    </div>
+          <div
+            className={css({
+              justifyContent: "center",
+              alignItems: "center",
+              width: `calc(100% - 13rem)`,
+              height: "100%",
+              display: "flex",
+            })}
+          >
+            <PDFPainter
+              painterId={`${sessionId}_${pdfDocument.fileId}`}
+              pdfDocumentURL={pdfDocument.url}
+              customPdfPainterControllerHook={pdfPainterControllerHook}
+            >
+              <PainterInstanceGenerator
+                instanceId={"Host"}
+                readOnly={true}
+                customPdfPainterInstanceControllerHook={
+                  pdfPainterHostInstanceControllerHook
+                }
+              />
+              <PainterInstanceGenerator
+                instanceId={"Participant"}
+                readOnly={false}
+                customPdfPainterInstanceControllerHook={
+                  pdfPainterParticipantInstanceControllerHook
+                }
+              />
+            </PDFPainter>
+          </div>
+        </div>
+      <PDFPainterControlBar
+        pdfPainterController={pdfPainterControllerHook.pdfPainterController}
+      />
+    </>
   );
 }

--- a/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
@@ -116,12 +116,30 @@ export default function ParticipantViewer(props: ViewerPropType) {
               }}
             />
             <ModeControl
-              labelText="내 필기 가리기"
+              labelText="호스트 필기 가리기"
               id="hide-host-draw"
+              checked={pdfPainterControllerHook.pdfPainterController.getInstanceHidden(
+                "Host"
+              )}
+              onChange={(e) => {
+                pdfPainterControllerHook.pdfPainterController.setInstanceHidden(
+                  "Host",
+                  e.target.checked
+                );
+              }}
             />
             <ModeControl
-              labelText="호스트 필기 가리기"
+              labelText="내 필기 가리기"
               id="hide-my-draw"
+              checked={pdfPainterControllerHook.pdfPainterController.getInstanceHidden(
+                "Participant"
+              )}
+              onChange={(e) => {
+                pdfPainterControllerHook.pdfPainterController.setInstanceHidden(
+                  "Participant",
+                  e.target.checked
+                );
+              }}
             />
           </>
         }

--- a/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
@@ -40,6 +40,7 @@ export default function ParticipantViewer(props: ViewerPropType) {
       editorId: "Participant",
       pdfPainterController: pdfPainterControllerHook.pdfPainterController,
     });
+  const {pdfPainterController} = pdfPainterControllerHook
   const { hostIndex } = useParticipantSocket(
     sessionId,
     fileId,
@@ -66,7 +67,7 @@ export default function ParticipantViewer(props: ViewerPropType) {
       >
         <PreviewPages
           pdfDocumentURL={pdfDocument.url}
-          PDFPainterController={pdfPainterControllerHook.pdfPainterController}
+          PDFPainterController={pdfPainterController}
           getBadgeVisible={(index) => index === hostIndex}
           getBadgeContent={(index) => {
             return <>{index !== undefined && hostIndex !== null && "!"}</>;
@@ -104,7 +105,7 @@ export default function ParticipantViewer(props: ViewerPropType) {
         </div>
       </div>
       <PDFPainterControlBar
-        pdfPainterController={pdfPainterControllerHook.pdfPainterController}
+        pdfPainterController={pdfPainterController}
         modeComponent={
           <>
             <ModeControl
@@ -118,11 +119,11 @@ export default function ParticipantViewer(props: ViewerPropType) {
             <ModeControl
               labelText="호스트 필기 가리기"
               id="hide-host-draw"
-              checked={pdfPainterControllerHook.pdfPainterController.getInstanceHidden(
+              checked={pdfPainterController.getInstanceHidden(
                 "Host"
               )}
               onChange={(e) => {
-                pdfPainterControllerHook.pdfPainterController.setInstanceHidden(
+                pdfPainterController.setInstanceHidden(
                   "Host",
                   e.target.checked
                 );
@@ -131,11 +132,11 @@ export default function ParticipantViewer(props: ViewerPropType) {
             <ModeControl
               labelText="내 필기 가리기"
               id="hide-my-draw"
-              checked={pdfPainterControllerHook.pdfPainterController.getInstanceHidden(
+              checked={pdfPainterController.getInstanceHidden(
                 "Participant"
               )}
               onChange={(e) => {
-                pdfPainterControllerHook.pdfPainterController.setInstanceHidden(
+                pdfPainterController.setInstanceHidden(
                   "Participant",
                   e.target.checked
                 );

--- a/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
+++ b/packages/front-end/app/view/[sessionId]/_components/ParticipantViewer.tsx
@@ -113,7 +113,6 @@ export default function ParticipantViewer(props: ViewerPropType) {
                 className={css({ margin: "0.25rem" })}
                 checked={isChaseMode}
                 onChange={(e) => {
-                  console.log("hello")
                   setIsChaseMode(e.target.checked);
                 }}
               />

--- a/packages/front-end/app/view/[sessionId]/_hooks/useEnsureVisibleWhileDraw.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useEnsureVisibleWhileDraw.ts
@@ -1,0 +1,11 @@
+import { PDFPainterController } from "@/PaintPDF/components";
+import { useEffect } from "react";
+
+export const useEnsureVisibleWhileDraw = (
+  editorId: string,
+  pdfPainterController: PDFPainterController
+) => {
+  useEffect(() => {
+    pdfPainterController.addIdEnsureVisibleWhileDraw(editorId);
+  }, [editorId, pdfPainterController]);
+};

--- a/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
@@ -59,7 +59,6 @@ export const useParticipantSocket = (
       "getHostPageNumber",
       (data: { fileId: number; index: number; userId: number }) => {
         setHostIndex(data.index);
-        console.log(isChaseMode,pdfPainterController.getPaintMode())
         if (pdfPainterController.getPaintMode() === "default" && isChaseMode) {
           console.log("This is chase mode")
           pdfPainterController.setPageIndex(data.index);

--- a/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
@@ -13,7 +13,8 @@ export const useParticipantSocket = (
   roomId: number | string,
   fileId: number,
   pdfPainterInstanceController: PDFPainterInstanceController,
-  pdfPainterController: PDFPainterController
+  pdfPainterController: PDFPainterController,
+  isChaseMode: boolean
 ) => {
   const editor = pdfPainterInstanceController.getEditor();
   const {
@@ -58,6 +59,9 @@ export const useParticipantSocket = (
       "getHostPageNumber",
       (data: { fileId: number; index: number; userId: number }) => {
         setHostIndex(data.index);
+        if (pdfPainterController.getPaintMode() === "default" && isChaseMode) {
+          pdfPainterController.setPageIndex(data.index);
+        }
       }
     );
     return () => {
@@ -115,5 +119,5 @@ export const useParticipantSocket = (
     socket,
     updateDrawCache,
   ]);
-  return {hostIndex}
+  return { hostIndex };
 };

--- a/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
@@ -59,7 +59,9 @@ export const useParticipantSocket = (
       "getHostPageNumber",
       (data: { fileId: number; index: number; userId: number }) => {
         setHostIndex(data.index);
+        console.log(isChaseMode,pdfPainterController.getPaintMode())
         if (pdfPainterController.getPaintMode() === "default" && isChaseMode) {
+          console.log("This is chase mode")
           pdfPainterController.setPageIndex(data.index);
         }
       }
@@ -67,7 +69,7 @@ export const useParticipantSocket = (
     return () => {
       socket.off("getHostPageNumber");
     };
-  }, [socket]);
+  }, [isChaseMode, pdfPainterController, socket]);
 
   useEffect(() => {
     if (socket === null) return;

--- a/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
+++ b/packages/front-end/app/view/[sessionId]/_hooks/useParticipantSocket.ts
@@ -60,7 +60,6 @@ export const useParticipantSocket = (
       (data: { fileId: number; index: number; userId: number }) => {
         setHostIndex(data.index);
         if (pdfPainterController.getPaintMode() === "default" && isChaseMode) {
-          console.log("This is chase mode")
           pdfPainterController.setPageIndex(data.index);
         }
       }

--- a/packages/front-end/panda.config.ts
+++ b/packages/front-end/panda.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   preflight: true,
 
   // Where to look for your css declarations
-  include: ["./components/**/*.{ts,tsx,js,jsx}", "./app/**/*.{ts,tsx,js,jsx}"],
+  include: ["./components/**/*.{ts,tsx,js,jsx}", "./app/**/*.{ts,tsx,js,jsx}","./PaintPDF/**/*.{ts,tsx,js,jsx}"],
 
   // Files to exclude
   exclude: [],


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 [#]
close #434 
## 📄 개요
- PaintPDF의 컨트롤바를 panda css로 변경
- 컨트롤바에 모드 버튼 추가
- 참여자가 호스트 페이지 따라가기 모드 활성화
- 참여자의 모드가 default일때만 추적

## 🔁 변경 사항
### 컨트롤 버튼
```typescript
const PDFPainterControlBarButtonComponent = styled("button", {
  base: {
    padding: "0.4em 0.8em",
    userSelect: "none",
    color: "#000000",
    backgroundColor: "#ffffff",
    cursor: "pointer",
    _disabled: {
      backgroundColor: "#d8d8d8",
      cursor: "default",
    },
  },
});
```
- styled를 이용해 props 자유도 부여 및 간단하게 스타일 작성
### 컨트롤바
```typescript
      <PDFPainterControlBar
        pdfPainterController={pdfPainterControllerHook.pdfPainterController}
        modeComponent={
          <>
            <div>
              <input
                type="checkbox"
                id="chase-host"
                className={css({ margin: "0.25rem" })}
                checked={isChaseMode}
                onChange={(e) => {
                  setIsChaseMode(e.target.checked);
                }}
              />
              <label htmlFor="chase-host">호스트 시점 따라가기</label>
            </div>
          </>
        }
      />
```
```typescript
      <div className={css({ position: "relative" })}>
        <PDFPainterControlBarButton
          onClick={() => {
            setShowToolTip(!showToolTip);
          }}
        >
          <p>{showToolTip ? "닫기" : "모드"}</p>
        </PDFPainterControlBarButton>
        {showToolTip && (
          <div
            className={css({
              position: "absolute",
              bottom: "100%",
              left:0,
              backgroundColor: "#fff",
              border: "2px solid black",
              borderRadius: "0.5rem",
              padding: "1rem",
              color:"#000",
              whiteSpace: "normal",
              zIndex:1000,
              width:"15rem"
            })}
          >
            {modeComponent}
          </div>
        )}
        
      </div>
```
- modeComponent로 mode pop over에 들어갈 컴포넌트 명시
- showToolTip 상태로 팝오버 가시 유무 제어
### 참여자 소켓
```typescript
  useEffect(() => {
    if (socket === null) return;
    socket.on(
      "getHostPageNumber",
      (data: { fileId: number; index: number; userId: number }) => {
        setHostIndex(data.index);
        if (pdfPainterController.getPaintMode() === "default" && isChaseMode) {
          console.log("This is chase mode")
          pdfPainterController.setPageIndex(data.index);
        }
      }
    );
    return () => {
      socket.off("getHostPageNumber");
    };
  }, [isChaseMode, pdfPainterController, socket]);
```
- 페인터모드와 추적모드 반영을 위해 의존성 배열 추가
### 필기 가리기(심층리뷰 바람)
```typescript
  const getInstanceHidden = useCallback(
    (editorId: string) => {
      return !!isInstanceHidden[editorId];
    },
    [isInstanceHidden]
  );

  const setInstanceHidden = useCallback(
    (editorId: string, isHidden: boolean) => {
      setIsInstanceHidden({ ...isInstanceHidden, [editorId]: isHidden });
    },
    [isInstanceHidden]
  );

```
- pdf controller에서 editor id로 히든 상태 제어
- 왜 Instance에서 못했냐면... 구현한다해도 어디서 어떻게 적용해야할지 감이 안옴 instance는 editor 관련 api 사용할때 가능할듯
- 미친 props drilling이나 context api쓰면 될 것 같긴한데...
- 어디다 해야할지 설계할때 어려움이 있었음
- 이정도면 쉽게 적용할 수 있어서 여기다 구현
```typescript
visibility: isInstanceHidden(element.props.instanceId) ? "hidden" : undefined
```
- <PainterInstance/>의 부모 div에 해당 스타일 적용
- 그리기 모드일땐 보여야하니까...
```
              checked={pdfPainterControllerHook.pdfPainterController.getInstanceHidden(
                "Participant"
              )}
              onChange={(e) => {
                pdfPainterControllerHook.pdfPainterController.setInstanceHidden(
                  "Participant",
                  e.target.checked
                );
              }}
```
- 해당 로직으로 인스턴스id에 따라 Get & Set 해주면 됨
### 그리기 모드일때 자기 필기 보이기
```typescript
// usePDFPainterController.ts
  const ensureVisibleWhileDrawRef = useRef<Set<string>>(new Set());

  const isIdEnsureVisibleWhileDraw = useCallback((editorId: string) => {
    return ensureVisibleWhileDrawRef.current.has(editorId);
  }, []);

  const addIdEnsureVisibleWhileDraw = useCallback((editorId: string) => {
    ensureVisibleWhileDrawRef.current.add(editorId);
  }, []);

  const deleteIdEnsureVisibleWhileDraw = useCallback((editorId: string) => {
    ensureVisibleWhileDrawRef.current.delete(editorId);
  }, []);

```
- 하나만 해도 되는데 구현에 별 차이 없어서 일단 set으로 (그래야 기획변경에 더 유연하니까?)
- ref로 내 필기가 가려져있어도 그리기 모드일때 강제로 보이게할 id를 관리
- 추가,삭제,읽기 가능
```typescript
// PDFPainter.tsx
  const isInstanceHidden = useCallback(
    (instanceId: string) => {
      return (
        pdfPainterController.getInstanceHidden(instanceId) &&
        !(
          pdfPainterController.getPaintMode() === "draw" &&
          pdfPainterController.isIdEnsureVisibleWhileDraw(instanceId)
        )
      );
    },
    [pdfPainterController]
  );
```
- 만약 가려야하고, (그리기 모드임과 동시에 그리기 모드일때 보여야하는 인스턴스 id)가 아니라면 가려짐
- 즉 보여야하는 인스턴스 id 외 다른 id라면 언제든지 자유롭게 show hide
- 즉 그리기 모드가 아니라면 언제든지 자유롭게 show hide
```typescript
import { PDFPainterController } from "@/PaintPDF/components";
import { useEffect } from "react";

export const useEnsureVisibleWhileDraw = (
  editorId: string,
  pdfPainterController: PDFPainterController
) => {
  useEffect(() => {
    pdfPainterController.addIdEnsureVisibleWhileDraw(editorId);
  }, [editorId, pdfPainterController]);
};
```
- 이렇게 useEffect로 id랑 컨트롤러 넘겨주면 안전하게 초기화할 수 있게함
- 사실 useEffect안써도 되긴하는데, 재랜더마다 set에 add하는게 낭비라고 생각
## 📸 동작 화면 스크린샷
![image](https://github.com/user-attachments/assets/df7bce01-c9dd-4b37-875f-4ed253cc53fc)
![image](https://github.com/user-attachments/assets/f10e3b26-08ab-424b-a355-911a00c6ab33)

## 👀 기타 논의 사항

### 나머지...
- 뭐가있을까요? 피드백바람
- PDFPainterControlBar 컴포넌트의 내부 버튼을 외부에서 주입받도록 하는게 어떨까요?
- PDFPainterControlBar가 ModeContainer를 의존해 더럽습니다.(의존 관계 계층이 꼬임) 이걸 지금 해결해야할까요?
## ⏰ 마감기한 회고
- panda CSS에 ./PaintPDF 경로를 명시해주지 않아 버그 추적에 오래걸렸다.
- 필기 show/hide 기능이 오래걸렸다. 각각의 상태 의존성을 파악해 무한 리랜더링을 막아야겠다. 단순 init하는 용도는 ref가 적절할 수 있다. 그럼 초기화시 무한 리랜더링 리스크가 사라진다.