### PR TITLE
fix: Get Sessions after Session deleted

### DIFF
--- a/packages/api-server/src/users/users.service.ts
+++ b/packages/api-server/src/users/users.service.ts
@@ -81,11 +81,19 @@ export class UsersService {
   }
 
   async getSessionsByHost(userId: number): Promise<Session[]> {
-    const sessions = await this.sessionRepository.find({
-      where: { hostId: userId },
+    const userSessions = await this.userSessionRepository.find({
+      where: { userId },
       order: { createdAt: 'DESC' },
-      take: 10,
     });
+
+    console.log(userSessions);
+
+    const sessions = (
+      await Promise.all(userSessions.map((userSession) => userSession.session))
+    )
+      .filter((session) => session.hostId === userId)
+      .sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt));
+
     return sessions;
   }
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 [#]
close #438 

## 📄 개요
- 내가 호스트일 때, 세션을 지우면 userSessions에서 지워지는데, sessions에서 내가 연 세션을 가져오게 되니까 지워도 목록에 남아있음. userSessions에서 가져온 뒤, 그 데이터 중 host가 나인 세션만 가져오기로 수정함.

## 🔁 변경 사항
### 변경 내용을 적어주세요 (커밋 번호를 적어주세요) 
- 왜, 어떻게 변경했는지 상세한 설명을 작성 (생략 가능)

## 📸 동작 화면 스크린샷

## 👀 기타 논의 사항

## ⏰ 마감기한 회고
- 마감기한에 비해 늦어졌다면 무엇이 병목이었는지, 빠르다면 무엇이 예상과 달리 쉬웠는지 등 회고