### PR TITLE
Be/451 get session host note

### DIFF
--- a/packages/api-server/src/auth/auth.controller.ts
+++ b/packages/api-server/src/auth/auth.controller.ts
@@ -151,10 +151,13 @@ export class AuthController {
   @ApiUnauthorizedResponse({ description: `Refresh token is not user's!` })
   @HttpCode(HttpStatus.CREATED)
   @Get('token-refresh')
-  async tokenRefresh(@Req() req: Request, @Res() res: Response): Promise<any> {
+  async tokenRefresh(
+    @Req() req: Request,
+    @UserId(ParseIntPipe) userId: number,
+    @Res() res: Response,
+  ): Promise<any> {
     const refreshToken = await this.authService.getRefreshTokenFromHeader(req);
-    const payload = req.user as JwtPayload;
-    const user: User = await this.authService.tokenValidateUser(payload);
+    const user: User = await this.authService.tokenValidateUser(userId);
     if (user.refreshToken !== refreshToken) {
       return res
         .status(HttpStatus.UNAUTHORIZED)

--- a/packages/api-server/src/auth/auth.controller.ts
+++ b/packages/api-server/src/auth/auth.controller.ts
@@ -164,8 +164,7 @@ export class AuthController {
         .json({ msg: `This refresh token is not user's token` });
     }
     const newAccessToken = await this.authService.generateAccessToken(user);
-    console.log(req.cookies.access_token);
-    console.log(newAccessToken);
+
     return res
       .cookie(
         'access_token',

--- a/packages/api-server/src/auth/auth.controller.ts
+++ b/packages/api-server/src/auth/auth.controller.ts
@@ -151,7 +151,7 @@ export class AuthController {
   @ApiUnauthorizedResponse({ description: `Refresh token is not user's!` })
   @HttpCode(HttpStatus.CREATED)
   @Get('token-refresh')
-  async tokenRefresh(@Req() req: Request, @Res() res): Promise<any> {
+  async tokenRefresh(@Req() req: Request, @Res() res: Response): Promise<any> {
     const refreshToken = await this.authService.getRefreshTokenFromHeader(req);
     const payload = req.user as JwtPayload;
     const user: User = await this.authService.tokenValidateUser(payload);
@@ -161,6 +161,8 @@ export class AuthController {
         .json({ msg: `This refresh token is not user's token` });
     }
     const newAccessToken = await this.authService.generateAccessToken(user);
+    console.log(req.cookies.access_token);
+    console.log(newAccessToken);
     return res
       .cookie(
         'access_token',

--- a/packages/api-server/src/auth/auth.service.ts
+++ b/packages/api-server/src/auth/auth.service.ts
@@ -81,8 +81,8 @@ export class AuthService implements OnModuleInit {
     });
   }
 
-  async tokenValidateUser(payload: JwtPayload) {
-    return await this.userService.findOneById(payload.id);
+  async tokenValidateUser(userId: number) {
+    return await this.userService.findOneById(userId);
   }
 
   async deleteRefreshTokenOfUser(userId: number) {

--- a/packages/api-server/src/users/users.controller.ts
+++ b/packages/api-server/src/users/users.controller.ts
@@ -225,4 +225,20 @@ export class UsersController {
     );
     return notes;
   }
+  @Get('session/:sessionId/file/:fileId/host-note/:pageNumber')
+  @ApiOkResponse({ type: Object })
+  @UseGuards(JwtGuard)
+  async getHostFileNotes(
+    @UserId(ParseIntPipe) userId: number,
+    @Param('sessionId') sessionId: number,
+    @Param('fileId') fileId: number,
+    @Param('pageNumber') pageNumber: number,
+  ) {
+    return await this.usersService.getHostFileNotes(
+      userId,
+      sessionId,
+      fileId,
+      pageNumber,
+    );
+  }
 }

--- a/packages/api-server/src/users/users.service.ts
+++ b/packages/api-server/src/users/users.service.ts
@@ -204,7 +204,7 @@ export class UsersService {
     fileId: number,
     pageNumber: number,
   ) {
-    const note = this.noteModel
+    const note = await this.noteModel
       .find({
         userId,
         sessionId,

--- a/packages/api-server/src/users/users.service.ts
+++ b/packages/api-server/src/users/users.service.ts
@@ -242,4 +242,25 @@ export class UsersService {
 
     return await newNote.save();
   }
+
+  async getHostFileNotes(
+    userId: number,
+    sessionId: number,
+    fileId: number,
+    pageNumber: number,
+  ) {
+    if (!(await this.userSessionRepository.findOneBy({ sessionId, userId }))) {
+      throw new BadRequestException("You didn't joined this session.");
+    }
+    const hostId = (await this.sessionRepository.findOneBy({ sessionId }))
+      ?.hostId;
+    return await this.noteModel
+      .find({
+        userId: hostId,
+        sessionId,
+        fileId,
+        pageNumber,
+      })
+      .exec();
+  }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가

## ❗️ 관련 이슈 [#]
close #451

## 📄 개요
- 일단 token-refresh는 테스트 해봤는데 res 타입을 제대로 안해줘서 그런건가 싶어서 바꿔서 테스트 해봤는데 일단 잘 동작함
- get /user/session/:sessionId/file/:fileId/host-note/:pageNumber로 요청하면 현재 접속해있는 세션의 host가 저장한 노트 가져옴

## 🔁 변경 사항
### 변경 내용을 적어주세요 (커밋 번호를 적어주세요)
- 왜, 어떻게 변경했는지 상세한 설명을 작성 (생략 가능)

## 📸 동작 화면 스크린샷

## 👀 기타 논의 사항

## ⏰ 마감기한 회고
- 마감기한에 비해 늦어졌다면 무엇이 병목이었는지, 빠르다면 무엇이 예상과 달리 쉬웠는지 등 회고