### PR TITLE
feat: pdf loading skeleton ui

### DIFF
--- a/packages/front-end/app/view/_components/PreviewPages.tsx
+++ b/packages/front-end/app/view/_components/PreviewPages.tsx
@@ -1,7 +1,9 @@
 import { PDFPainterController } from "@/PaintPDF/components";
 import { css } from "@/styled-system/css";
-import { MouseEventHandler, ReactNode, useRef } from "react";
+import { MouseEventHandler, ReactNode } from "react";
 import { Document, Page, pdfjs } from "react-pdf";
+import Placeholder from "@/components/Placeholder/Placeholder";
+import PlaceholderLayout from "@/components/Placeholder/PlaceholderLayout";
 
 const options = {
   cMapUrl: `//unpkg.com/pdfjs-dist@${pdfjs.version}/cmaps/`,
@@ -37,6 +39,20 @@ export function PreviewPages({
     >
       <Document
         file={pdfDocumentURL}
+        loading={
+          <PlaceholderLayout
+            width={160}
+            type={"vertical"}
+            gap={"1em"}
+            alignItems={"flex-start"}
+          >
+            <Placeholder width={160} height={90} type={"box"} />
+            <Placeholder width={160} height={90} type={"box"} />
+            <Placeholder width={160} height={90} type={"box"} />
+            <Placeholder width={160} height={90} type={"box"} />
+            <Placeholder width={160} height={90} type={"box"} />
+          </PlaceholderLayout>
+        }
         className={css({
           display: "flex",
           flexDirection: "column",
@@ -48,6 +64,8 @@ export function PreviewPages({
         {Array.from(new Array(pageCount), (el, index) => (
           <PageElement
             key={`page-${index}`}
+            width={160}
+            height={90}
             index={index}
             onClick={() => {
               PDFPainterController.setPageIndex(index);
@@ -63,12 +81,16 @@ export function PreviewPages({
 }
 
 function PageElement({
+  width,
+  height,
   index,
   onClick,
   currentIndex,
   isBadgeVisible = false,
   badgeContent,
 }: {
+  width: number;
+  height: number;
   index: number;
   currentIndex: number;
   onClick?: MouseEventHandler<HTMLDivElement>;
@@ -87,12 +109,35 @@ function PageElement({
         })}
       >
         <Page
+          loading={
+            <PlaceholderLayout
+              height={height}
+              type={"vertical"}
+              gap={"0.5em"}
+              alignItems={"flex-start"}
+            >
+              <Placeholder
+                width={width / 2}
+                type={"text"}
+                lineCount={1}
+                lineHeight={"1em"}
+                lineGap={0}
+              />
+              <Placeholder
+                width={width}
+                height={"100%"}
+                type={"text"}
+                lineCount={4}
+                lineHeight={"0.7em"}
+                lineGap={0}
+              />
+            </PlaceholderLayout>
+          }
           pageNumber={index + 1}
-          width={1600}
-          height={900}
+          width={width}
+          height={height}
           renderTextLayer={false}
           renderAnnotationLayer={false}
-          scale={0.1}
         />
         {isBadgeVisible && (
           <div

--- a/packages/front-end/app/view/_components/PreviewPages.tsx
+++ b/packages/front-end/app/view/_components/PreviewPages.tsx
@@ -111,6 +111,7 @@ function PageElement({
         <Page
           loading={
             <PlaceholderLayout
+              padding={"0.3em"}
               height={height}
               type={"vertical"}
               gap={"0.5em"}

--- a/packages/front-end/components/Placeholder/Placeholder.tsx
+++ b/packages/front-end/components/Placeholder/Placeholder.tsx
@@ -8,6 +8,7 @@ interface PlaceholderProps {
   lineCount?: number;
   lineHeight?: CSSProperties["lineHeight"];
   lineGap?: CSSProperties["gap"];
+  justifyContent?: CSSProperties["justifyContent"];
   borderRadius?: CSSProperties["borderRadius"];
 }
 
@@ -18,6 +19,7 @@ const Placeholder = ({
   lineCount = 1,
   lineHeight = "1em",
   lineGap = "1em",
+  justifyContent = "space-between",
   borderRadius = "0.2em",
 }: PlaceholderProps) => {
   if (type === "text") {
@@ -25,10 +27,15 @@ const Placeholder = ({
       <div
         className={css({
           display: "flex",
-          justifyContent: "center",
+          flexDirection: "column",
           alignItems: "center",
         })}
-        style={{ gap: lineGap }}
+        style={{
+          width: width,
+          height: height,
+          justifyContent: justifyContent,
+          gap: lineGap,
+        }}
       >
         {Array.from({ length: lineCount }, (_, index) => (
           <div

--- a/packages/front-end/components/Placeholder/PlaceholderLayout.tsx
+++ b/packages/front-end/components/Placeholder/PlaceholderLayout.tsx
@@ -7,6 +7,8 @@ interface PlaceholderLayoutProps {
   width?: CSSProperties["width"];
   height?: CSSProperties["height"];
   gap?: CSSProperties["gap"];
+  justifyContent?: CSSProperties["justifyContent"];
+  alignItems?: CSSProperties["alignItems"];
   children: ReactNode;
 }
 
@@ -16,6 +18,8 @@ const PlaceholderLayout = ({
   width,
   height,
   gap = "0.2em",
+  justifyContent = "center",
+  alignItems = "center",
   children,
 }: PlaceholderLayoutProps) => {
   return (
@@ -23,17 +27,17 @@ const PlaceholderLayout = ({
       className={cx(
         css({
           display: "flex",
-          justifyContent: "center",
-          alignItems: "center",
         }),
         type === "vertical"
-          ? css({ flexDirection: "row" })
-          : css({ flexDirection: "column" }),
+          ? css({ flexDirection: "column" })
+          : css({ flexDirection: "row" }),
       )}
       style={{
         padding: padding,
         width: width,
         height: height,
+        justifyContent: justifyContent,
+        alignItems: alignItems,
         gap: gap,
       }}
     >


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [X] 개발

## ❗️ 관련 이슈 [#]
close #458 

## 📄 개요
- PDF loading skeleton ui
- 최종 디자인이 아니며 PDF 로딩 중 skeleton ui가 렌더링 될 수 있도록 구현해둔 것
- 추후 실제 디자인이 적용될때 skeleton 디자인만 약간 수정하면 되도록 구현


<img width="153" alt="image" src="https://github.com/user-attachments/assets/caabe853-5655-4ad2-bbc0-cdf4a6a4a051">


<img width="153" alt="image" src="https://github.com/user-attachments/assets/82dcc9ba-9aaa-4bc3-a5a9-f015fbfd0af3">
