### PR TITLE
fix: note schema options

### DIFF
--- a/packages/api-server/src/users/schemas/note.schema.ts
+++ b/packages/api-server/src/users/schemas/note.schema.ts
@@ -1,22 +1,22 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document } from 'mongoose';
 
-@Schema()
+@Schema({ minimize: false })
 export class Note extends Document {
-  @Prop()
+  @Prop({ require: true, type: Number })
   userId: number;
 
-  @Prop()
+  @Prop({ require: true, type: Number })
   sessionId: number;
 
-  @Prop()
+  @Prop({ require: true, type: Number })
   fileId: number;
 
-  @Prop()
+  @Prop({ require: true, type: Number })
   pageNumber: number;
 
-  @Prop({ type: Object })
-  data: any;
+  @Prop({ require: true, type: Object, default: {} })
+  data: object;
 }
 
 export const NoteSchema = SchemaFactory.createForClass(Note);


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 [#]
close #457 

## 📄 개요
- mongoDB에 빈 오브젝트 넣으면 필터링 해서 안들어감
- 찾아보다가 못찾겠어서 gpt한테 물어봄

## 🔁 변경 사항
### 변경 내용을 적어주세요 (커밋 번호를 적어주세요)
```
@Schema({ minimize: false })
export class Note extends Document {
  ....
  @Prop({ require: true, type: Object, default: {} })
  data: object;
}
```
- Schema 에 `minimize` 옵션이 있었음

> Mongoose will, by default, "minimize" schemas by removing empty objects. This behavior can be overridden by setting minimize option to false. It will then store empty objects.

- minimize를 false로 세팅하니까 빈 오브젝트가 잘 들어간다😄
- 하는 김에 Prop에 타입 설정이 안돼있어서 타입 설정까지 함.

## 📸 동작 화면 스크린샷

## 👀 기타 논의 사항

## ⏰ 마감기한 회고
- 마감기한에 비해 늦어졌다면 무엇이 병목이었는지, 빠르다면 무엇이 예상과 달리 쉬웠는지 등 회고