### PR TITLE
feat: color palette visualize

### DIFF
--- a/packages/front-end/stories/Color.stories.tsx
+++ b/packages/front-end/stories/Color.stories.tsx
@@ -1,0 +1,62 @@
+import { Meta, StoryFn, StoryObj } from "@storybook/react";
+import ColorPalette from "./ColorPalette";
+import { css } from "@/styled-system/css";
+import { theme } from "@/style/theme";
+import { useState } from "react";
+import Switch from "@/components/Switch";
+import React from "react";
+
+const meta = {
+  title: "Color/Palette",
+  component: React.Fragment,
+  parameters: {
+    layout: "centered",
+  },
+} satisfies Meta<typeof React.Fragment>;
+
+type Story = StoryObj<typeof meta>;
+export default meta;
+
+const Template: StoryFn = (_args) => {
+  const [background, setBackground] = useState(true);
+  return (
+    <div
+      className={css({ padding: "1rem" })}
+      style={
+        background
+          ? { color: "black", backgroundColor: "white" }
+          : { color: "white", backgroundColor: "black" }
+      }
+    >
+      <h1 className={css({ fontWeight: "bold", fontSize: "2rem" })}>
+        Color Palette
+      </h1>
+      <label
+        className={css({
+          margin: "1rem 0",
+          fontWeight: "semibold",
+          fontSize: "1.5rem",
+          display: "block",
+        })}
+        htmlFor="background"
+      >
+        Set background
+      </label>
+      <Switch
+        checked={background}
+        onChange={(e) => {
+          setBackground(e.target.checked);
+        }}
+        name="background"
+        id="background"
+      />
+      <ColorPalette title="primary" palette={theme.colors?.primary} />
+      <ColorPalette title="secondary" palette={theme.colors?.secondary} />
+      <ColorPalette title="tertiary" palette={theme.colors?.tertiary} />
+      <ColorPalette title="grey" palette={theme.colors?.grey} />
+    </div>
+  );
+};
+
+export const Default: Story = Template.bind({
+});

--- a/packages/front-end/stories/ColorPalette.tsx
+++ b/packages/front-end/stories/ColorPalette.tsx
@@ -1,0 +1,57 @@
+import { css } from "@/styled-system/css";
+import { Recursive, Token } from "@/styled-system/types/composition";
+
+export default function ColorPalette({
+  palette,
+  title,
+}: {
+  palette?:
+    | { [key in number | string]: { value: string } }
+    | Token<string>
+    | Recursive<Token<string>>;
+  title: string;
+}) {
+  return (
+    <section>
+      <h2
+        className={css({
+          fontWeight: "semibold",
+          fontSize: "1.5rem",
+          margin: "1rem 0",
+        })}
+      >
+        {title}
+      </h2>
+      <div className={css({ display: "flex", flexWrap: "wrap", gap: "1rem" })}>
+        {palette &&
+          Object.entries(palette).map(([key, value]) => (
+            <div
+              key={key}
+              className={css({
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                gap: "0.35rem",
+              })}
+            >
+              <div
+                className={css({
+                  width: "5em",
+                  height: "5em",
+                  border: "1px solid",
+                  borderColor: "grey.200",
+                })}
+                style={{
+                  backgroundColor: value.value,
+                }}
+              />
+              <p>{key}</p>
+              <p className={css({ fontSize: "0.75rem", opacity: "0.8" })}>
+                {value.value}
+              </p>
+            </div>
+          ))}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 [#]
#469 
## 📄 개요
- 스토리북을 활용ㅎ한 컬러테마 시각화

## 🔁 변경 사항
- 우리가 사용하는 grey,primary,secondary, tertiary 컬러를 직접 시각화
- 해당 화면보면서 컬러 입히는 작업하면 좋을 것 같음
- 컬러 설정시 에러 확인 가능
- theme를 직접 import해 theme를 변경하면 스토리북에 반영되도록함
- 각 섹션마다 컬러를 나눈 레이아웃으로 식별이 용이하게함
- 컬러, 이름, 헥스코드를 볼 수 있게함
- 흰색배경, 검은배경에서 컬러를 확인할 수 있게함(스위치로 조절)
- 동적인스타일은 build time css인 panda로 구현이 힘드므로 `style` props로 런타임에 주입, 어차피 개발자가 쓰는거라...
- 그냥 단순한 docs역할 스토리는 mdx로 작업하거나 React.Fragement로 컴포넌트 타입 지정하면 됨
## 📸 동작 화면 스크린샷
![image](https://github.com/user-attachments/assets/b61c2495-c3f9-45cf-9947-f819fcd60f57)

## 👀 기타 논의 사항
- 몇개는 이미 잘못설정하고 있었다니...
## ⏰ 마감기한 회고
- 생산성을 위한 추가적인 작업