### PR TITLE
487 table

### DIFF
--- a/packages/front-end/app/(sidebar-pages)/files/_components/FileTable.tsx
+++ b/packages/front-end/app/(sidebar-pages)/files/_components/FileTable.tsx
@@ -9,6 +9,12 @@ import ModalContainer from "@/components/ModalContainer";
 import FileUploadModal from "@/components/FileUploader/FileUploadModal";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiClient } from "@/utils/axios";
+import { Heading } from "@/components/Text";
+import DeleteIcon from "@/public/icons/delete.svg";
+import UploadIcon from "@/public/icons/upload.svg"
+import SessionIcon from "@/public/icons/session.svg";
+
+
 
 const showFileUploadModal = () => {
   overlay.open(
@@ -17,7 +23,7 @@ const showFileUploadModal = () => {
         <FileUploadModal />
       </ModalContainer>
     ),
-    { overlayId: "File-Upload" },
+    { overlayId: "File-Upload" }
   );
 };
 
@@ -89,7 +95,7 @@ export function FileTable({
       Promise.all(
         selectedItems.map(async (e) => {
           await apiClient.delete(`/file/${e}`);
-        }),
+        })
       ),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["user", "files"] });
@@ -106,43 +112,47 @@ export function FileTable({
         display: "flex",
         flexDirection: "column",
         gap: "0.6em",
+        fontSize: "0.8rem",
+        fontWeight: "semibold",
       })}
     >
       <div
-        className={css({
-          display: "flex",
-          gap: "1em",
-          justifyContent: "flex-end",
-        })}
+        className={css({ display: "flex", justifyContent: "space-between" })}
       >
-        <Button
+        <Heading>강의 자료</Heading>
+        <div
           className={css({
-            padding: "0.5em 0.8em",
+            display: "flex",
+            gap: "1em",
+            justifyContent: "flex-end",
           })}
-          onClick={() => showFileUploadModal()}
         >
-          새 파일 업로드
-        </Button>
-        <Button
-          className={css({
-            padding: "0.5em 0.8em",
-          })}
-          disabled={selectedItems.length === 0}
-          onClick={() => {
-            console.log(`Delete Button Clicked`);
-            console.log(selectedItems);
-            fileMutate.mutate(selectedItems);
-            setSelectedItems([]);
-          }}
-        >
-          선택한 파일 삭제
-        </Button>
+          <Button
+            onClick={() => showFileUploadModal()}
+            startIcon={<UploadIcon width={"1em"} height={"1em"} />}
+          >
+            새 파일 업로드
+          </Button>
+          <Button
+            disabled={selectedItems.length === 0}
+            onClick={() => {
+              fileMutate.mutate(selectedItems);
+              setSelectedItems([]);
+            }}
+            startIcon={<DeleteIcon width={"1em"} height={"1em"} />}
+            color="gray"
+          >
+            선택한 파일 삭제
+          </Button>
+        </div>
       </div>
+
       <SelectableTable
         head={[
           {
             id: 0,
             value: "이름",
+            align: "left",
           },
           {
             id: 1,

--- a/packages/front-end/app/(sidebar-pages)/files/_components/FileTable.tsx
+++ b/packages/front-end/app/(sidebar-pages)/files/_components/FileTable.tsx
@@ -2,7 +2,7 @@ import { File } from "@/schema/backend.schema";
 import { css } from "@/styled-system/css";
 import { formatDate } from "date-fns";
 import { useState } from "react";
-import Button from "@/components/Button";
+import Button from "@/components/Button/Button";
 import SelectableTable from "@/components/SelectableTable";
 import { overlay } from "overlay-kit";
 import ModalContainer from "@/components/ModalContainer";

--- a/packages/front-end/app/(sidebar-pages)/files/page.tsx
+++ b/packages/front-end/app/(sidebar-pages)/files/page.tsx
@@ -7,8 +7,6 @@ import FileTableFetcher from "./_fetcher/FileTableFetcher";
 export default function Page() {
   return (
     <div>
-      <Heading>드라이브</Heading>
-      <Divider />
       <FileTableFetcher />
     </div>
   );

--- a/packages/front-end/app/(sidebar-pages)/sessions/_components/SessionFormTemplate.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/_components/SessionFormTemplate.tsx
@@ -1,4 +1,4 @@
-import Button from "@/components/Button";
+import Button from "@/components/Button/Button";
 import FileUploadAndSelectModal from "@/components/FileUploadAndSelectModal";
 import { Label } from "@/components/Label";
 import LineEdit from "@/components/LineEdit";

--- a/packages/front-end/app/(sidebar-pages)/sessions/detail/[sessionId]/_components/ParticipantSession/index.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/detail/[sessionId]/_components/ParticipantSession/index.tsx
@@ -1,4 +1,4 @@
-import Button from "@/components/Button";
+import Button from "@/components/Button/Button";
 import { Label } from "@/components/Label";
 import { Paragraph } from "@/components/Text";
 import { useRouter } from "@/hook/useRouter";
@@ -36,7 +36,7 @@ export default function ParticipantSession({ sessionData }: PropType) {
           <Paragraph key={file.fileId}>{file.name}</Paragraph>
         ))}
       </Container>
-      <Divider/>
+      <Divider />
       <Button
         onClick={() => {
           router.push(

--- a/packages/front-end/app/(sidebar-pages)/sessions/host/_components/HostSessionTable.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/host/_components/HostSessionTable.tsx
@@ -1,4 +1,4 @@
-import Button from "@/components/Button";
+import Button from "@/components/Button/Button";
 import LinkButton from "@/components/LinkButton";
 import { useRouter } from "@/hook/useRouter";
 import { Session } from "@/schema/backend.schema";
@@ -9,6 +9,8 @@ import SelectableTable from "@/components/SelectableTable";
 import { PROJECT_NAME } from "@/const/config";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiClient } from "@/utils/axios";
+import { Heading } from "@/components/Text";
+import DeleteIcon from "@/public/icons/delete.svg"
 
 const DataEmptyPlaceholder = (
   <div
@@ -99,33 +101,37 @@ export function HostSessionTable({
       })}
     >
       <div
-        className={css({
-          display: "flex",
-          gap: "1em",
-          justifyContent: "flex-end",
-        })}
+        className={css({ display: "flex", justifyContent: "space-between" })}
       >
-        <LinkButton
+        <Heading>내가 주최한 세션</Heading>
+        <div
           className={css({
-            padding: "0.5em 0.8em",
+            display: "flex",
+            gap: "1em",
+            justifyContent: "flex-end",
           })}
-          href="/sessions/create"
         >
-          새로 만들기
-        </LinkButton>
-        <Button
-          className={css({
-            padding: "0.5em 0.8em",
-          })}
-          disabled={selectedItems.length === 0}
-          onClick={() => {
-            sessionMutate.mutate(selectedItems);
-            setSelectedItems([]);
-          }}
-        >
-          선택한 세션 삭제
-        </Button>
+          <LinkButton
+            className={css({
+              padding: "0.5em 0.8em",
+            })}
+            href="/sessions/create"
+          >
+            새로 만들기
+          </LinkButton>
+          <Button
+            disabled={selectedItems.length === 0}
+            onClick={() => {
+              sessionMutate.mutate(selectedItems);
+              setSelectedItems([]);
+            }}
+            startIcon={<DeleteIcon width={"1em"} height={"1em"} />}
+          >
+            선택한 세션 삭제
+          </Button>
+        </div>
       </div>
+
       <SelectableTable
         head={[
           {
@@ -167,7 +173,7 @@ export function HostSessionTable({
                 className={css({
                   padding: "0.5em 0.8em",
                 })}
-                href={{pathname:"/view",query:{id:item.sessionId}}}
+                href={{ pathname: "/view", query: { id: item.sessionId } }}
                 onClick={(e) => {
                   e.stopPropagation();
                 }}

--- a/packages/front-end/app/(sidebar-pages)/sessions/host/_components/HostSessionTable.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/host/_components/HostSessionTable.tsx
@@ -1,5 +1,4 @@
 import Button from "@/components/Button/Button";
-import LinkButton from "@/components/LinkButton";
 import { useRouter } from "@/hook/useRouter";
 import { Session } from "@/schema/backend.schema";
 import { css } from "@/styled-system/css";
@@ -10,7 +9,10 @@ import { PROJECT_NAME } from "@/const/config";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiClient } from "@/utils/axios";
 import { Heading } from "@/components/Text";
-import DeleteIcon from "@/public/icons/delete.svg"
+import DeleteIcon from "@/public/icons/delete.svg";
+import LinkButton from "@/components/Button/LinkButton";
+import SessionIcon from "@/public/icons/session.svg";
+import JoinIcon from "@/public/icons/join.svg";
 
 const DataEmptyPlaceholder = (
   <div
@@ -21,15 +23,14 @@ const DataEmptyPlaceholder = (
       justifyContent: "center",
       alignItems: "center",
       gap: "0.5em",
+      color: "gray.500",
     })}
   >
     <p>표시할 데이터가 없습니다.</p>
     <p>새로운 {PROJECT_NAME} 세션을 생성해 보세요!</p>
     <LinkButton
-      className={css({
-        padding: "0.5em 0.8em",
-      })}
       href="/sessions/create"
+      startIcon={<SessionIcon width={"1em"} height={"1em"} />}
     >
       새로 만들기
     </LinkButton>
@@ -98,6 +99,8 @@ export function HostSessionTable({
         display: "flex",
         flexDirection: "column",
         gap: "0.6em",
+        fontSize: "0.8rem",
+        fontWeight: "semibold",
       })}
     >
       <div
@@ -109,13 +112,12 @@ export function HostSessionTable({
             display: "flex",
             gap: "1em",
             justifyContent: "flex-end",
+            fontWeight: "medium",
           })}
         >
           <LinkButton
-            className={css({
-              padding: "0.5em 0.8em",
-            })}
             href="/sessions/create"
+            startIcon={<SessionIcon width={"1em"} height={"1em"} />}
           >
             새로 만들기
           </LinkButton>
@@ -126,6 +128,7 @@ export function HostSessionTable({
               setSelectedItems([]);
             }}
             startIcon={<DeleteIcon width={"1em"} height={"1em"} />}
+            color="gray"
           >
             선택한 세션 삭제
           </Button>
@@ -137,6 +140,7 @@ export function HostSessionTable({
           {
             id: 0,
             value: "제목",
+            align: "left",
           },
           {
             id: 1,
@@ -154,7 +158,7 @@ export function HostSessionTable({
             id: 3,
             value: "빠른 작업",
             width: "10vw",
-            minWidth: "8em",
+            minWidth: "6em",
           },
         ]}
         body={data.map((item) => {
@@ -162,24 +166,32 @@ export function HostSessionTable({
             id: item.sessionId,
             values: [
               <div key={0}>{item.sessionName}</div>,
-              <div key={1}>
+              <div key={1} className={css({})}>
                 {formatDate(item.createdAt, "yyyy-MM-dd HH:mm:ss")}
               </div>,
-              <div key={2}>
-                {item.closedAt ? `${item.closedAt}에 종료됨` : "진행 중"}
-              </div>,
-              <LinkButton
-                key={3}
+              <div
+                key={2}
                 className={css({
-                  padding: "0.5em 0.8em",
+                  color: item.closedAt ? "grey.500" : "primary.200",
                 })}
-                href={{ pathname: "/view", query: { id: item.sessionId } }}
-                onClick={(e) => {
-                  e.stopPropagation();
-                }}
               >
-                세션 시작
-              </LinkButton>,
+                {item.closedAt ? `종료됨` : "진행중"}
+              </div>,
+              <div
+                key={3}
+                className={css({ display: "flex", justifyContent: "center" })}
+              >
+                <LinkButton
+                  href={{ pathname: "/view", query: { id: item.sessionId } }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                  }}
+                  size="small"
+                  startIcon={<JoinIcon width={"1em"} height={"1em"} />}
+                >
+                  세션 시작
+                </LinkButton>
+              </div>,
             ],
             onClick: () => router.push(`/sessions/detail/${item.sessionId}`),
           };

--- a/packages/front-end/app/(sidebar-pages)/sessions/host/page.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/host/page.tsx
@@ -7,8 +7,7 @@ import Divider from "@/components/Divider";
 export default function Page() {
   return (
     <>
-      <Heading>내가 주최한 세션</Heading>
-      <Divider />
+
       <HostSessionTableFetcher />
     </>
   );

--- a/packages/front-end/app/(sidebar-pages)/sessions/join/page.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/join/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import LineEdit from "@/components/LineEdit";
 import { css } from "@/styled-system/css";
-import Button from "@/components/Button";
+import Button from "@/components/Button/Button";
 import { Label } from "@/components/Label";
 import { useRouter } from "@/hook/useRouter";
 import { routeTitle } from "@/const/routeTitle";
@@ -36,7 +36,7 @@ export default function Page() {
           alignItems: "flex-start",
           flexGrow: 1,
           justifyContent: "center",
-          padding:"3rem 4.16rem"
+          padding: "3rem 4.16rem"
         })}
       >
         <div
@@ -65,7 +65,7 @@ export default function Page() {
             })}
             onClick={() => {
               if (sessionCode.trim() === "") {
-                toast("세션 코드를 입력해주세요.", { type: "error",position:"top-center" });
+                toast("세션 코드를 입력해주세요.", { type: "error", position: "top-center" });
                 return;
               }
               router.push(

--- a/packages/front-end/app/(sidebar-pages)/sessions/participant/_components/ParticipantSessionTable.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/participant/_components/ParticipantSessionTable.tsx
@@ -11,7 +11,6 @@ import { apiClient } from "@/utils/axios";
 import { Heading } from "@/components/Text";
 import DeleteIcon from "@/public/icons/delete.svg";
 import LinkButton from "@/components/Button/LinkButton";
-import SessionIcon from "@/public/icons/session.svg";
 import JoinIcon from "@/public/icons/join.svg";
 
 const DataEmptyPlaceholder = (
@@ -117,12 +116,10 @@ export function ParticipantSessionTable({
             display: "flex",
             gap: "1em",
             justifyContent: "flex-end",
+            fontWeight: "medium",
           })}
         >
           <LinkButton
-            className={css({
-              padding: "0.5em 0.8em",
-            })}
             href="/sessions/join"
             startIcon={<JoinIcon width={"1em"} height={"1em"} />}
           >

--- a/packages/front-end/app/(sidebar-pages)/sessions/participant/_components/ParticipantSessionTable.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/participant/_components/ParticipantSessionTable.tsx
@@ -1,5 +1,4 @@
 import Button from "@/components/Button/Button";
-import LinkButton from "@/components/LinkButton";
 import { useRouter } from "@/hook/useRouter";
 import { Session } from "@/schema/backend.schema";
 import { css } from "@/styled-system/css";
@@ -9,6 +8,11 @@ import SelectableTable from "@/components/SelectableTable";
 import { PROJECT_NAME } from "@/const/config";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiClient } from "@/utils/axios";
+import { Heading } from "@/components/Text";
+import DeleteIcon from "@/public/icons/delete.svg";
+import LinkButton from "@/components/Button/LinkButton";
+import SessionIcon from "@/public/icons/session.svg";
+import JoinIcon from "@/public/icons/join.svg";
 
 const DataEmptyPlaceholder = (
   <div
@@ -100,41 +104,49 @@ export function ParticipantSessionTable({
         display: "flex",
         flexDirection: "column",
         gap: "0.6em",
+        fontSize: "0.8rem",
+        fontWeight: "semibold",
       })}
     >
       <div
-        className={css({
-          display: "flex",
-          gap: "1em",
-          justifyContent: "flex-end",
-        })}
+        className={css({ display: "flex", justifyContent: "space-between" })}
       >
-        <LinkButton
+        <Heading>내가 참가한 세션</Heading>
+        <div
           className={css({
-            padding: "0.5em 0.8em",
+            display: "flex",
+            gap: "1em",
+            justifyContent: "flex-end",
           })}
-          href="/sessions/join"
         >
-          새 세션 참여하기
-        </LinkButton>
-        <Button
-          className={css({
-            padding: "0.5em 0.8em",
-          })}
-          disabled={selectedItems.length === 0}
-          onClick={() => {
-            sessionMutate.mutate(selectedItems);
-            setSelectedItems([]);
-          }}
-        >
-          선택한 기록 삭제
-        </Button>
+          <LinkButton
+            className={css({
+              padding: "0.5em 0.8em",
+            })}
+            href="/sessions/join"
+            startIcon={<JoinIcon width={"1em"} height={"1em"} />}
+          >
+            새 세션 참여하기
+          </LinkButton>
+          <Button
+            disabled={selectedItems.length === 0}
+            onClick={() => {
+              sessionMutate.mutate(selectedItems);
+              setSelectedItems([]);
+            }}
+            color="gray"
+            startIcon={<DeleteIcon width={"1em"} height={"1em"} />}
+          >
+            선택한 세션 삭제
+          </Button>
+        </div>
       </div>
       <SelectableTable
         head={[
           {
             id: 0,
             value: "제목",
+            align: "left",
           },
           {
             id: 1,
@@ -163,21 +175,29 @@ export function ParticipantSessionTable({
               <div key={1}>
                 {formatDate(item.createdAt, "yyyy-MM-dd HH:mm:ss")}
               </div>,
-              <div key={2}>
-                {item.closedAt ? `${item.closedAt}에 종료됨` : "진행 중"}
-              </div>,
-              <LinkButton
-                key={3}
+              <div
+                key={2}
                 className={css({
-                  padding: "0.5em 0.8em",
+                  color: item.closedAt ? "grey.500" : "primary.200",
                 })}
-                href={{ pathname: "/view", query: { id: item.sessionId } }}
-                onClick={(e) => {
-                  e.stopPropagation();
-                }}
               >
-                세션 참여
-              </LinkButton>,
+                {item.closedAt ? `종료됨` : "진행중"}
+              </div>,
+              <div
+                key={3}
+                className={css({ display: "flex", justifyContent: "center" })}
+              >
+                <LinkButton
+                  size="small"
+                  href={{ pathname: "/view", query: { id: item.sessionId } }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                  }}
+                  startIcon={<JoinIcon width={"1em"} height={"1em"} />}
+                >
+                  세션 참여
+                </LinkButton>
+              </div>,
             ],
             onClick: () => router.push(`/sessions/detail/${item.sessionId}`),
           };

--- a/packages/front-end/app/(sidebar-pages)/sessions/participant/_components/ParticipantSessionTable.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/participant/_components/ParticipantSessionTable.tsx
@@ -1,4 +1,4 @@
-import Button from "@/components/Button";
+import Button from "@/components/Button/Button";
 import LinkButton from "@/components/LinkButton";
 import { useRouter } from "@/hook/useRouter";
 import { Session } from "@/schema/backend.schema";
@@ -171,7 +171,7 @@ export function ParticipantSessionTable({
                 className={css({
                   padding: "0.5em 0.8em",
                 })}
-                href={{pathname:"/view",query:{id:item.sessionId}}}
+                href={{ pathname: "/view", query: { id: item.sessionId } }}
                 onClick={(e) => {
                   e.stopPropagation();
                 }}

--- a/packages/front-end/app/(sidebar-pages)/sessions/participant/page.tsx
+++ b/packages/front-end/app/(sidebar-pages)/sessions/participant/page.tsx
@@ -1,14 +1,10 @@
 "use client";
 
-import { Heading } from "@/components/Text";
 import ParticipantSessionTableFetcher from "./_fetcher/ParticipantSessionTableFetcher";
-import Divider from "@/components/Divider";
 
 export default function Page() {
   return (
     <>
-      <Heading>내가 참가한 세션</Heading>
-      <Divider />
       <ParticipantSessionTableFetcher />
     </>
   );

--- a/packages/front-end/app/(sidebar-pages)/settings/_components/UserProfileSettings.tsx
+++ b/packages/front-end/app/(sidebar-pages)/settings/_components/UserProfileSettings.tsx
@@ -1,4 +1,4 @@
-import Button from "@/components/Button";
+import Button from "@/components/Button/Button";
 import { css } from "@/styled-system/css";
 import { useRef, useState, ChangeEvent, ReactNode } from "react";
 import LineEdit from "@/components/LineEdit";
@@ -111,10 +111,10 @@ const UserProfileSettings = () => {
             size="small"
             startIcon={<CameraIcon width={"1em"} height={"1em"} />}
             className={css({
-              width:"100%",
+              width: "100%",
             })}
           >
-            <p className={css({textAlign:"center",flex:1,})}>사진 변경</p>
+            <p className={css({ textAlign: "center", flex: 1, })}>사진 변경</p>
           </Button>
           <input
             type="file"

--- a/packages/front-end/app/help/page.tsx
+++ b/packages/front-end/app/help/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Button from "@/components/Button";
+import Button from "@/components/Button/Button";
 import { useRouter } from "@/hook/useRouter";
 import { apiClient } from "@/utils/axios";
 import { useMutation, useQueryClient } from "@tanstack/react-query";

--- a/packages/front-end/app/view/_components/Common/CodeOverlay.tsx
+++ b/packages/front-end/app/view/_components/Common/CodeOverlay.tsx
@@ -1,4 +1,4 @@
-import Button from "@/components/Button";
+import Button from "@/components/Button/Button";
 import { Heading, Paragraph } from "@/components/Text";
 import { useRouter } from "@/hook/useRouter";
 import { css } from "@/styled-system/css";
@@ -106,12 +106,12 @@ export function CodeOverlay({ code }: { code: string }) {
           copyToClipboard(code, "코드");
         }}
         className={css({
-          cursor:"pointer",
+          cursor: "pointer",
           transition: "opacity 0.3s ease",
           fontSize: "10rem",
-          fontWeight:"bold",
-          "&:hover":{
-            opacity:0.7,
+          fontWeight: "bold",
+          "&:hover": {
+            opacity: 0.7,
           }
         })}
       >

--- a/packages/front-end/app/view/_components/Common/Download.tsx
+++ b/packages/front-end/app/view/_components/Common/Download.tsx
@@ -1,4 +1,4 @@
-import Button from "@/components/Button";
+import Button from "@/components/Button/Button";
 import { ModeControl } from "./Mode";
 import { css } from "@/styled-system/css";
 import { Dispatch, SetStateAction, useEffect, useRef, useState } from "react";
@@ -44,10 +44,10 @@ export function HostViewerDownload({
     }
     const snapshotsFromServer = hostDrawControlRef.current.checked
       ? await getSelfDrawFromServer(
-          pdfPainterController.getPageCount(),
-          sessionId,
-          fileId
-        )
+        pdfPainterController.getPageCount(),
+        sessionId,
+        fileId
+      )
       : [];
     const pdfBytes = await getMergedPDFBytes(src, async (index) => [
       await pageEachDrawCallback({
@@ -125,18 +125,18 @@ export function ParticipantViewerDownload({
     }
     const snapshotsFromServer = partiDrawControlRef.current.checked
       ? await getSelfDrawFromServer(
-          pdfPainterController.getPageCount(),
-          sessionId,
-          fileId
-        )
+        pdfPainterController.getPageCount(),
+        sessionId,
+        fileId
+      )
       : [];
     const hostSnapshotsFromServer = hostDrawControlRef.current.checked
       ? await getSelfDrawFromServer(
-          pdfPainterController.getPageCount(),
-          sessionId,
-          fileId,
-          true
-        )
+        pdfPainterController.getPageCount(),
+        sessionId,
+        fileId,
+        true
+      )
       : [];
     const pdfBytes = await getMergedPDFBytes(src, async (index) => [
       await pageEachDrawCallback({

--- a/packages/front-end/app/view/_components/Host/HostViewer.tsx
+++ b/packages/front-end/app/view/_components/Host/HostViewer.tsx
@@ -16,7 +16,7 @@ import { useEnsureVisibleWhileDraw } from "../../_hooks/useEnsureVisibleWhileDra
 import { useState } from "react";
 import { CodeOverlay, CodeOverlayContainer } from "../Common/CodeOverlay";
 import { usePostDraw } from "../../_hooks/usePostDraw";
-import Button from "@/components/Button";
+import Button from "@/components/Button/Button";
 import { HostViewerDownload } from "../Common/Download";
 import { Header } from "../Common/Header";
 import { PageControl } from "../Common/PageControl";

--- a/packages/front-end/app/view/_components/Participant/ParticipantViewer.tsx
+++ b/packages/front-end/app/view/_components/Participant/ParticipantViewer.tsx
@@ -19,7 +19,7 @@ import { ModeControl } from "../Common/Mode";
 import { useEnsureVisibleWhileDraw } from "../../_hooks/useEnsureVisibleWhileDraw";
 import { CodeOverlay, CodeOverlayContainer } from "../Common/CodeOverlay";
 import { usePostDraw } from "../../_hooks/usePostDraw";
-import Button from "@/components/Button";
+import Button from "@/components/Button/Button";
 import { ParticipantViewerDownload } from "../Common/Download";
 import { Header } from "../Common/Header";
 import { PageControl } from "../Common/PageControl";

--- a/packages/front-end/components/Button/Button.tsx
+++ b/packages/front-end/components/Button/Button.tsx
@@ -1,10 +1,11 @@
-import { styled, StyledComponent } from "@/styled-system/jsx";
+import { styled } from "@/styled-system/jsx";
 import {
   ButtonHTMLAttributes,
   DetailedHTMLProps,
   forwardRef,
   ReactNode,
 } from "react";
+
 
 const ButtonContainer = styled("button", {
   base: {

--- a/packages/front-end/components/Button/LinkButton.tsx
+++ b/packages/front-end/components/Button/LinkButton.tsx
@@ -1,0 +1,90 @@
+import { styled } from "@/styled-system/jsx";
+import { LinkPropsReal } from "@/type/PropTypes/LinkPropType";
+import Link from "next/link";
+import {
+  AnchorHTMLAttributes,
+  DetailedHTMLProps,
+  forwardRef,
+  ReactNode,
+} from "react";
+
+const ButtonContainer = styled(Link, {
+  base: {
+    padding: "0.48rem 0.38rem",
+    bg: "primary.200",
+    borderRadius: "0.3rem",
+    color: "white",
+    cursor: "pointer",
+    fontWeight: "medium",
+    display: "flex",
+    gap: "0.375rem",
+    alignItems: "center",
+  },
+  variants: {
+    isIcon: {
+      true: {
+        justifyContent: "",
+      },
+      false: {
+        justifyContent: "center",
+      },
+    },
+    size: {
+      mid: {
+        fontSize: "1rem",
+      },
+      small: {
+        fontSize: "0.8rem",
+        padding: "0.3rem 0.38rem",
+      },
+    },
+    color: {
+      primary: {
+        bg: "primary.200",
+        _hover: {
+          bg: "primary.400",
+        },
+      },
+      secondary: {
+        bg: "secondary.200",
+        color: "black",
+        _hover: {
+          bg: "secondary.dark",
+        },
+      },
+      gray: {
+        bg: "grey.500",
+        _hover: {
+          bg: "#6F7291",
+        },
+      },
+    },
+  },
+  defaultVariants: {
+    color: "primary",
+    size: "mid",
+  },
+});
+
+interface PropType
+  extends LinkPropsReal {
+  children?: ReactNode;
+  startIcon?: ReactNode;
+  size?: "small" | "mid" | undefined;
+  color?: "primary" | "secondary" | "gray" | undefined;
+}
+
+const LinkButton = forwardRef<HTMLAnchorElement, PropType>(
+  ({ children, startIcon, ...attr }, ref) => {
+    return (
+      <ButtonContainer ref={ref} {...attr} isIcon={!!startIcon}>
+        {startIcon}
+        {children}
+      </ButtonContainer>
+    );
+  }
+);
+
+LinkButton.displayName = "LinkButton";
+
+export default LinkButton;

--- a/packages/front-end/components/Checkbox.tsx
+++ b/packages/front-end/components/Checkbox.tsx
@@ -1,16 +1,25 @@
 import { css, cx } from "@/styled-system/css";
-import { ChangeEventHandler, MouseEventHandler } from "react";
+import {
+  ChangeEventHandler,
+  DetailedHTMLProps,
+  InputHTMLAttributes,
+  MouseEventHandler,
+} from "react";
 
+interface PropType
+  extends DetailedHTMLProps<
+    InputHTMLAttributes<HTMLInputElement>,
+    HTMLInputElement
+  > {}
 
-interface PropType {
-  className?: string;
-  checked?: boolean;
-  onChange?: ChangeEventHandler<HTMLInputElement>;
-  onClick?: MouseEventHandler<HTMLInputElement>;
-  disabled?: boolean;
-}
-
-export default function Checkbox({className, checked, onChange, onClick, disabled}: PropType) {
+export default function Checkbox({
+  className,
+  checked,
+  onChange,
+  onClick,
+  disabled,
+  ...attr
+}: PropType) {
   return (
     <input
       type="checkbox"
@@ -18,11 +27,17 @@ export default function Checkbox({className, checked, onChange, onClick, disable
       onChange={onChange}
       onClick={onClick}
       disabled={disabled}
-      className={cx(css({
-        display: "block",
-        width: "1.3em",
-        height: "1.3em",
-      }), className)}
+      className={cx(
+        css({
+          display: "block",
+          width: "1.3em",
+          height: "1.3em",
+          fontSize:"1em",
+          accentColor:"primary.200",
+        }),
+        className
+      )}
+      {...attr}
     />
   );
-};
+}

--- a/packages/front-end/components/FileUploadAndSelectModal/DriveFileSelect.tsx
+++ b/packages/front-end/components/FileUploadAndSelectModal/DriveFileSelect.tsx
@@ -10,7 +10,7 @@ import { apiClient } from "@/utils/axios";
 import { useQuery } from "@tanstack/react-query";
 import { AxiosResponse } from "axios";
 import { File } from "@/schema/backend.schema";
-import Button from "@/components/Button";
+import Button from "@/components/Button/Button";
 import { formatDate } from "date-fns";
 import { overlay } from "overlay-kit";
 import { FileFormDataContext } from ".";

--- a/packages/front-end/components/FileUploadAndSelectModal/index.tsx
+++ b/packages/front-end/components/FileUploadAndSelectModal/index.tsx
@@ -10,7 +10,7 @@ import {
   useState,
 } from "react";
 import { Heading } from "../Text";
-import Button from "../Button";
+import Button from "../Button/Button";
 import { ErrorBoundary } from "react-error-boundary";
 import { useQueryErrorResetBoundary } from "@tanstack/react-query";
 import FileUploader from "@/components/FileUploader/FileUploader";

--- a/packages/front-end/components/FileUploader/FileUploadModal.tsx
+++ b/packages/front-end/components/FileUploader/FileUploadModal.tsx
@@ -1,4 +1,4 @@
-import Button from "@/components/Button";
+import Button from "@/components/Button/Button";
 import FileUploader from "@/components/FileUploader/FileUploader";
 import { Heading } from "@/components/Text";
 import { css } from "@/styled-system/css";

--- a/packages/front-end/components/FileUploader/FileUploadPreview.tsx
+++ b/packages/front-end/components/FileUploader/FileUploadPreview.tsx
@@ -1,7 +1,7 @@
 import { css, cx } from "@/styled-system/css";
 import { format } from "date-fns";
 import formatByteSize from "@/utils/formatByteSize";
-import Button from "@/components/Button";
+import Button from "@/components/Button/Button";
 import CloseIcon from "@/public/icons/close.svg";
 import DocumentIcon from "@/public/icons/document.svg";
 import PdfIcon from "@/public/icons/pdf.svg";
@@ -28,10 +28,10 @@ function openFileInNewTab(file: File): void {
       return;
     const url = URL.createObjectURL(
       new Blob([event.target.result],
-      {
-        type: file.type
-      }
-    ));
+        {
+          type: file.type
+        }
+      ));
     window.open(url, "_blank");
   };
   reader.onerror = (event) => {
@@ -142,7 +142,7 @@ const FileUploadPreview = forwardRef(({ className, file, removeButtonClickHandle
       </div>
       {
         status === "ready"
-        ?
+          ?
           <Button
             className={css({
               padding: "0.1em",
@@ -171,12 +171,12 @@ const FileUploadPreview = forwardRef(({ className, file, removeButtonClickHandle
           width: `${progress}%`,
           backgroundColor: (
             status === "uploading"
-            ?
+              ?
               "#fc7328"
               :
               (
                 status === "error"
-                ?
+                  ?
                   "#e80000"
                   :
                   "#00c40a"

--- a/packages/front-end/components/FileUploader/FileUploader.tsx
+++ b/packages/front-end/components/FileUploader/FileUploader.tsx
@@ -10,7 +10,7 @@ import {
   useEffect,
 } from "react";
 import { useDropzone } from "react-dropzone";
-import Button from "@/components/Button";
+import Button from "@/components/Button/Button";
 import FileUploadPreview from "@/components/FileUploader/FileUploadPreview";
 import PlusCircleIcon from "@/public/icons/plus-circle.svg";
 import PlusIcon from "@/public/icons/plus.svg";

--- a/packages/front-end/components/SelectableTable.tsx
+++ b/packages/front-end/components/SelectableTable.tsx
@@ -1,7 +1,14 @@
-import { TableContainer, TableHead, TableRow, TableBody, Th, Td } from "@/components/Table";
+import {
+  TableContainer,
+  TableHead,
+  TableRow,
+  TableBody,
+  Th,
+  Td,
+} from "@/components/Table";
 import { Dispatch, ReactNode, SetStateAction } from "react";
 import Checkbox from "@/components/Checkbox";
-
+import { css } from "@/styled-system/css";
 
 interface PropType {
   head: {
@@ -9,85 +16,102 @@ interface PropType {
     value: ReactNode;
     width?: string;
     minWidth?: string;
+    align?: "left" | "right" | "center";
   }[];
   body: {
     id: number;
     values: ReactNode[];
     onClick?: () => void;
-  }[],
-  placeholder?: ReactNode,
-  selectedItems: number[]
-  setSelectedItems: Dispatch<SetStateAction<number[]>>
+  }[];
+  placeholder?: ReactNode;
+  selectedItems: number[];
+  setSelectedItems: Dispatch<SetStateAction<number[]>>;
 }
 
-
-export default function SelectableTable({ head, body, placeholder, selectedItems, setSelectedItems }: PropType) {
+export default function SelectableTable({
+  head,
+  body,
+  placeholder,
+  selectedItems,
+  setSelectedItems,
+}: PropType) {
   return (
-    <TableContainer>
+    <TableContainer className={css({ marginTop: "0.35rem" })}>
       <TableHead>
         <TableRow>
           <Th width="3em">
             <Checkbox
-              checked={body.length === selectedItems.length && selectedItems.length !== 0}
+              checked={
+                body.length === selectedItems.length &&
+                selectedItems.length !== 0
+              }
               onChange={() => {
                 if (body.length === selectedItems.length) {
                   setSelectedItems([]);
-                }
-                else {
+                } else {
                   setSelectedItems(body.map((item) => item.id));
                 }
               }}
               disabled={body.length === 0}
             />
           </Th>
-          {
-            head.map((item) => {
-              return (
-                <Th key={item.id} style={{
+          {head.map((item) => {
+            return (
+              <Th
+                key={item.id}
+                style={{
                   width: item.width,
-                  minWidth: item.minWidth
-                }}>{item.value}</Th>
-              );
-            })
-          }
+                  minWidth: item.minWidth,
+                }}
+                align={item.align ? item.align : "center"}
+              >
+                <div className={css({ width: "100%", padding: "0.35rem 0" })}>
+                  {item.value}
+                </div>
+              </Th>
+            );
+          })}
         </TableRow>
       </TableHead>
       <TableBody>
-        {
-          body.length === 0
-          ?
-            <TableRow>
-              <Td colSpan={head.length + 1}>{placeholder}</Td>
-            </TableRow>
-            :
-            body.map(item => {
-              return (
-                <TableRow key={item.id} onClick={item.onClick}>
-                  <Td onClick={(event) => event.stopPropagation()}>
-                    <Checkbox
-                      checked={selectedItems.includes(item.id)}
-                      onChange={() => {
-                        if (selectedItems.includes(item.id)) {
-                          setSelectedItems(selectedItems.filter((id) => id !== item.id));
-                        }
-                        else {
-                          setSelectedItems([...selectedItems, item.id]);
-                        }
-                      }}
-                      onClick={(event) => event.stopPropagation()}
-                    />
-                  </Td>
-                  {
-                    item.values.map((value, index) => {
-                      return (
-                        <Td key={index}>{value}</Td>
-                      );
-                    })
-                  }
-                </TableRow>
-              );
-            })
-        }
+        {body.length === 0 ? (
+          <TableRow>
+            <Td colSpan={head.length + 1}>{placeholder}</Td>
+          </TableRow>
+        ) : (
+          body.map((item) => {
+            return (
+              <TableRow key={item.id} onClick={item.onClick}>
+                <Td onClick={(event) => event.stopPropagation()}>
+                  <Checkbox
+                    checked={selectedItems.includes(item.id)}
+                    onChange={() => {
+                      if (selectedItems.includes(item.id)) {
+                        setSelectedItems(
+                          selectedItems.filter((id) => id !== item.id)
+                        );
+                      } else {
+                        setSelectedItems([...selectedItems, item.id]);
+                      }
+                    }}
+                    onClick={(event) => event.stopPropagation()}
+                  />
+                </Td>
+                {item.values.map((value, index) => {
+                  return (
+                    <Td key={index} align={index === 0 ? "left" : "center"}>
+                      <div
+                        className={css({ width: "100%", padding: "0.35rem 0" })}
+                      >
+                        {value}
+                      </div>
+                    </Td>
+                  );
+                })}
+              </TableRow>
+            );
+          })
+        )}
       </TableBody>
     </TableContainer>
   );

--- a/packages/front-end/components/Table.tsx
+++ b/packages/front-end/components/Table.tsx
@@ -7,7 +7,10 @@ export const TableContainer = styled("table", {
   base: {
     borderCollapse: "collapse",
     border: "1px solid",
-    borderColor: "gray.200",
+    borderColor: "grey.300",
+    borderLeft:"none",
+    borderRight:"none",
+    borderTop:"none",
   },
   variants: {
     fullWidth: {

--- a/packages/front-end/components/Text.tsx
+++ b/packages/front-end/components/Text.tsx
@@ -45,7 +45,8 @@ export const Paragraph = styled("p", {
 
 export const Heading = styled("h1", {
   base: {
-    fontWeight: 700,
+    fontWeight: "semibold",
+    color: "black",
   },
   variants: {
     variant: {
@@ -94,6 +95,6 @@ export const Heading = styled("h1", {
     },
   },
   defaultVariants: {
-    variant: "h3",
+    variant: "h5",
   },
 });

--- a/packages/front-end/public/icons/delete.svg
+++ b/packages/front-end/public/icons/delete.svg
@@ -1,0 +1,14 @@
+<svg viewBox="0 0 19 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_236_436)">
+<path d="M16.25 5L15.38 17.14C15.31 18.19 14.43 19 13.39 19H5.11C4.06 19 3.19 18.19 3.12 17.14L2.25 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11.25 9.52979V14.5298" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.25 9.52979V14.5298" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M5.75 5V2.5C5.75 1.67 6.42 1 7.25 1H11.25C12.08 1 12.75 1.67 12.75 2.5V5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M17.75 5H0.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_236_436">
+<rect width="18.5" height="19.5" fill="currentColor" transform="translate(0 0.25)"/>
+</clipPath>
+</defs>
+</svg>

--- a/packages/front-end/public/icons/join-regacy.svg
+++ b/packages/front-end/public/icons/join-regacy.svg
@@ -1,0 +1,19 @@
+<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_236_862)">
+<path d="M13.75 19H15.75C17.41 19 18.75 17.66 18.75 16V14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13.75 1H15.75C17.41 1 18.75 2.34 18.75 4V6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9.75 10H14.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12.75 6.5H14.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4.75 6.5H9.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4.75 10H6.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4.75 13.5H9.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12.75 13.5H14.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M0.75 14V16C0.75 17.66 2.09 19 3.75 19H5.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M0.75 6V4C0.75 2.34 2.09 1 3.75 1H5.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_236_862">
+<rect width="19.5" height="19.5" fill="currentColor" transform="translate(0 0.25)"/>
+</clipPath>
+</defs>
+</svg>

--- a/packages/front-end/public/icons/join.svg
+++ b/packages/front-end/public/icons/join.svg
@@ -1,19 +1,12 @@
-<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_236_862)">
-<path d="M13.75 19H15.75C17.41 19 18.75 17.66 18.75 16V14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M13.75 1H15.75C17.41 1 18.75 2.34 18.75 4V6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M9.75 10H14.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M12.75 6.5H14.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M4.75 6.5H9.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M4.75 10H6.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M4.75 13.5H9.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M12.75 13.5H14.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M0.75 14V16C0.75 17.66 2.09 19 3.75 19H5.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M0.75 6V4C0.75 2.34 2.09 1 3.75 1H5.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<svg viewBox="0 0 15 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_236_424)">
+<path d="M9.34007 8.5H1.57007" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.01001 10.8299L9.34001 8.49992L7.01001 6.16992" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M0.75 11.6099C1.08 12.2899 1.53 12.9099 2.06 13.4499C4.79 16.1799 9.23 16.1799 11.96 13.4499C14.69 10.7199 14.69 6.27994 11.96 3.54994C9.23 0.819942 4.79 0.819942 2.06 3.54994C1.53 4.08994 1.08 4.70994 0.75 5.38994" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 </g>
 <defs>
-<clipPath id="clip0_236_862">
-<rect width="19.5" height="19.5" fill="currentColor" transform="translate(0 0.25)"/>
+<clipPath id="clip0_236_424">
+<rect width="14.76" height="15.5" fill="currentColor" transform="translate(0 0.75)"/>
 </clipPath>
 </defs>
 </svg>

--- a/packages/front-end/public/icons/upload.svg
+++ b/packages/front-end/public/icons/upload.svg
@@ -1,0 +1,13 @@
+<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_236_1071)">
+<path d="M9.75 5.5V10.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.5 7.75L9.75 5.5L12 7.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M5.75 14H13.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13.75 1H5.75C2.98858 1 0.75 3.23858 0.75 6V14C0.75 16.7614 2.98858 19 5.75 19H13.75C16.5114 19 18.75 16.7614 18.75 14V6C18.75 3.23858 16.5114 1 13.75 1Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_236_1071">
+<rect width="19.5" height="19.5" fill="currentColor" transform="translate(0 0.25)"/>
+</clipPath>
+</defs>
+</svg>

--- a/packages/front-end/stories/Button.stories.tsx
+++ b/packages/front-end/stories/Button.stories.tsx
@@ -1,10 +1,10 @@
 import type { Meta, StoryFn, StoryObj } from "@storybook/react";
-import Button from "@/components/Button";
+import Button from "@/components/Button/Button";
 import Icon from "@/public/icons/settings.svg";
 import { ReactNode } from "react";
 
 const meta = {
-  title: "Components/Button",
+  title: "Components/Button/Button",
   component: Button,
   parameters: {
     layout: "centered",
@@ -22,8 +22,8 @@ const meta = {
       },
       options: ["primary", "secondary", "gray"],
     },
-    startIcon:{
-      control:false,
+    startIcon: {
+      control: false,
     }
   },
 } satisfies Meta<typeof Button>;

--- a/packages/front-end/stories/LinkButton.stories.tsx
+++ b/packages/front-end/stories/LinkButton.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import Icon from "@/public/icons/settings.svg";
+import LinkButton from "@/components/Button/LinkButton";
+
+const meta = {
+  title: "Components/Button/LinkButton",
+  component: LinkButton,
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {
+    size: {
+      control: {
+        type: "radio",
+      },
+      options: ["mid", "small"],
+    },
+    color: {
+      control: {
+        type: "radio",
+      },
+      options: ["primary", "secondary", "gray"],
+    },
+    startIcon: {
+      control: false,
+    },
+  },
+} satisfies Meta<typeof LinkButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+
+export const Default: Story = {
+    args: {
+        children: "LinkButton",
+        size: "mid",
+        color: "primary",
+        href: "/",
+        startIcon: <Icon width={"1em"} height={"1em"} />, // Inline JSX directly
+    },
+};


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 [#]
close #487
## 📄 개요
### 테이블 UI
- 참여자 세션 목록
- 호스트 세션 목록
- 파일 목록

## 🔁 변경 사항
### 공용컴포넌트
#### 버튼
- 버튼 폴더를 만들어서 스타일이 같은 링크버튼과 같은 디렉토리에 배치
- recipe를 복붙하려했지만 **타입 추론이 안돼서** 일단 복사붙여넣기로 해결
- 공통 레시피를 사용하는 법이 있나 찾아봐야겠음
- 링크버튼 스토리북 작성
#### 체크박스
- Accent color로 스타일링
- Accent color는 2021년후반 이후 브라우저 버전에서 호환되는 불안정한 속성
- 체크박스 배경과 체크된 배경은 커스텀하려면 중노동이 요구됨 일단 이정도까지만했음(체크됐을때 남색 배경)
#### 테이블
- 상하 보더를 제거함
#### 선택 가능 테이블
- 각 col마다 align 속성을 정해줄 수 있게함
- 테이블 상단에 마진을 부여함(개발툴이 없어서 디자인 시안상 헤더랑 얼마나 떨어져있는지 파악이 안됨)
- 테이블 content에 div를 덧씌워 기본 테이블 layout을 유지하면서도 유연한 스타일링이 가능하도록함
  - 예를들어 상단에 패딩을 줌
  - 예를들어 버튼이 테이블 col 너비에 맞춰 쫙 늘어나는걸 방지함
- 0번째 item는 col과 같이 align left 하드코딩함 (제목)
- 제목이 center에 존재한다면 이상함 확실히 이상함
#### 페이지
- 예외적으로 Heading을 Page.tsx가 아니라 직접 컴포넌트 내부에 배치함
- page.tsx에서 따로빼기엔 로직을 어떻게 처리할지 전혀 감이 안잡힘, 내부에 배치하는게 딱히 어렵지도 않고 최선인듯
- 시안상 "종료됨"에 시간이 딱히 없고 나도 그게 글자수도 맞는 것 같아서(CLS 방지) 그렇게 했음  
## 📸 동작 화면 스크린샷
![image](https://github.com/user-attachments/assets/445c951a-457f-48d5-98ae-f7a443b76443)
![image](https://github.com/user-attachments/assets/37fdeaad-7249-4124-8ca4-c76f20c9171f)
![image](https://github.com/user-attachments/assets/9879e188-8e25-4582-a012-8c92d3def7a2)
마지막 사진 좌측하단 파란색은 그래픽처리 오류
## 👀 기타 논의 사항
- 코드 품질이 레전드입니다.
## ⏰ 마감기한 회고
- 끝끝!! 그래도 사진보고 이상한거 있음 말해주세요