### PR TITLE
fix: send draw

### DIFF
--- a/packages/front-end/app/view/_hooks/useHostSocket.ts
+++ b/packages/front-end/app/view/_hooks/useHostSocket.ts
@@ -62,12 +62,15 @@ export const useHostSocket = (
     if (editor === null) return;
     const { store } = editor;
 
-    store.listen(
+    const clean = store.listen(
       ({ changes }) => {
         pushChanges(changes);
       },
       { source: "user", scope: "document" }
     );
+    // return () => {
+    //   store.listen(clean);
+    // };
   }, [editor, pushChanges, socket]);
 
   return {roomPageViewerCount};

--- a/packages/front-end/app/view/_hooks/usePostDraw.ts
+++ b/packages/front-end/app/view/_hooks/usePostDraw.ts
@@ -24,10 +24,6 @@ export const usePostDraw = (
     const clean = store.listen(
       ({ changes }) => {
         changedPageIndexRef.current.add(pdfPainterController.getPageIndex());
-        console.log(
-          "Add change page index!",
-          pdfPainterController.getPageIndex()
-        );
       },
       { source: "user", scope: "document" }
     );
@@ -56,7 +52,6 @@ export const usePostDraw = (
     toDeleteSet.forEach((index) => {
       changedPageIndexRef.current.delete(index);
     });
-    console.log("I delete!", changedPageIndexRef.current);
   }, [fileId, pdfPainterController, pdfPainterInstanceController, sessionId]);
 
   useEffect(() => {

--- a/packages/front-end/app/view/_hooks/usePostDraw.ts
+++ b/packages/front-end/app/view/_hooks/usePostDraw.ts
@@ -3,7 +3,7 @@ import {
   PDFPainterInstanceController,
 } from "@/PaintPDF/components";
 import { apiClient } from "@/utils/axios";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 const intervalTime = (1000 * 60 * 1) / 3;
 export const usePostDraw = (
@@ -14,47 +14,73 @@ export const usePostDraw = (
 ) => {
   const editor = pdfPainterInstanceController.getEditor();
   const changedPageIndexRef = useRef<Set<number>>(new Set<number>());
+  const intervalProcessRef = useRef<{ id: NodeJS.Timeout; start: number }[]>(
+    []
+  );
 
   useEffect(() => {
     if (editor === null) return;
     const { store } = editor;
-
-    store.listen(
+    const clean = store.listen(
       ({ changes }) => {
         changedPageIndexRef.current.add(pdfPainterController.getPageIndex());
+        console.log(
+          "Add change page index!",
+          pdfPainterController.getPageIndex()
+        );
       },
       { source: "user", scope: "document" }
     );
+
+    // return () => {
+    //   store.listen(clean);
+    // };
   }, [editor, pdfPainterController]);
 
-  useEffect(() => {
-    const sendPostRequest = async () => {
-      const width = pdfPainterController.getPage()?.originalWidth;
-      const height = pdfPainterController.getPage()?.originalHeight;
-      const tempPageSet = new Set<number>();
-      changedPageIndexRef.current.forEach((index) => {
-        tempPageSet.add(index);
-      });
-      tempPageSet.forEach((index) => {
-        const note =
-          pdfPainterInstanceController.getEditorSnapshotFromStorage(index);
-        if (note === null || width === undefined || height === undefined) {
-          return;
-        }
-        apiClient.post(
-          `/user/session/${sessionId}/file/${fileId}/note/${index}`,
-          { note: note, width, height }
-        );
-        changedPageIndexRef.current.delete(index);
-      });
-    };
+  const sendPostRequest = useCallback(async () => {
+    const width = pdfPainterController.getPage()?.originalWidth;
+    const height = pdfPainterController.getPage()?.originalHeight;
+    const toDeleteSet = new Set<number>();
+    changedPageIndexRef.current.forEach((index) => {
+      toDeleteSet.add(index);
+      const note =
+        pdfPainterInstanceController.getEditorSnapshotFromStorage(index);
+      if (note === null || width === undefined || height === undefined) {
+        return;
+      }
+      apiClient.post(
+        `/user/session/${sessionId}/file/${fileId}/note/${index}`,
+        { note: note, width, height }
+      );
+    });
+    toDeleteSet.forEach((index) => {
+      changedPageIndexRef.current.delete(index);
+    });
+    console.log("I delete!", changedPageIndexRef.current);
+  }, [fileId, pdfPainterController, pdfPainterInstanceController, sessionId]);
 
+  useEffect(() => {
     const intervalId = setInterval(() => {
       sendPostRequest();
     }, intervalTime);
+    intervalProcessRef.current.push({ id: intervalId, start: Date.now() });
 
     return () => {
-      clearInterval(intervalId);
+      const end = Date.now();
+      const copiedIntervalProcess: { id: NodeJS.Timeout; start: number }[] = [];
+      const toDelete: NodeJS.Timeout[] = [];
+      intervalProcessRef.current.forEach(({ id, start }) => {
+        copiedIntervalProcess.push({ id, start });
+      });
+      copiedIntervalProcess.forEach(({ id, start }) => {
+        if (end - start > intervalTime) {
+          clearInterval(id);
+          toDelete.push(id);
+        }
+      });
+      intervalProcessRef.current = intervalProcessRef.current.filter(
+        ({ id }) => !toDelete.includes(id)
+      );
     };
-  }, [fileId, pdfPainterInstanceController, sessionId]);
+  }, [sendPostRequest]);
 };


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 [#]
close #493 
## 📄 개요
- 완전 해결 못할 것 같습니다...
- 일단 특정 주기마다 보내긴 보냄
- **결국에 그 주기를 최대한 짧게하는 대신 유실을 감수하며 방식을 간소화하는걸로 진행**

## 🔁 변경 사항
### 이전
#### SetInterval
```typescript
useEffect(()=>{
  const id = setInterval(()=>{
    // logic....
  },time}
  return () => {
    clearInterval(id)
  }
},[deps])
```
- useEffect내에서 setInterval을 사용시 clean up func에 interval을 clear한다.
- 이는 메모리 누수 방지 및 굳이 더 처리가 되지 말아야할 interval logic을 제거해주는 역할이다.
- 하지만 문제는 interval이 끝나기전 deps가 바뀐다면 로직이 취소된다.
따라서 동작은 하기 위해 이렇게 바꾸었다.
```typescript
  useEffect(() => {
    const intervalId = setInterval(() => {
      sendPostRequest();
    }, intervalTime);
    intervalProcessRef.current.push({ id: intervalId, start: Date.now() });

    return () => {
      const end = Date.now();
      const copiedIntervalProcess: { id: NodeJS.Timeout; start: number }[] = [];
      const toDelete: NodeJS.Timeout[] = [];
      intervalProcessRef.current.forEach(({ id, start }) => {
        copiedIntervalProcess.push({ id, start });
      });
      copiedIntervalProcess.forEach(({ id, start }) => {
        if (end - start > intervalTime) {
          clearInterval(id);
          toDelete.push(id);
        }
      });
      intervalProcessRef.current = intervalProcessRef.current.filter(
        ({ id }) => !toDelete.includes(id)
      );
    };
  }, [sendPostRequest]);
``` 
- interval logic 실행시 시작 시간을 interval id와 매칭해 넣어준다.
- clean up func가 실행시 현재 시간을 가져온다.
- interval id의 시작시간과 현재 시간을 비교해 만약 주기보다 더 길다면 지워준다.
- **하지만 이 로직 자체 역시 es-lint가 경고해주는 것 처럼 time을 다루는 데이터는 cleanup하기 전에 useEffect내에서 깊은 복사를 하고 진행하라고 한다.**
  - 나 역시도 이에 어느정도 동의하나, 현재로선 예상치 못한 동작을 파악 못하겠고
  - 이를 고치면 코드 구조가 어떻게 깔끔해질지 의문이다.
  - [참고링크](https://stackoverflow.com/questions/67069827/cleanup-ref-issues-in-react)
- 사실 큰 문제는 후술할 문제이다.
### 이후
- 주기를 5초로 짧게 설정
- 간단하게, 변화가 발생한다면 set에 넣고 set에 현재 페이지번호가 있으면(변화가 발생했다면) send
- 의존성배열이 바뀔때마다 interval 작업 완료와 무관하게 메모리를 클린시킴

## 📸 동작 화면 스크린샷

## 👀 기타 논의 사항
### 어떻게 해야하지...
- store.listen 역시 이벤트 리스너를 추가하므로 메모리 누수 가능성이 있다.
- **정말 큰 문제는 이미 post 요청을 보낸 페이지도 보낸다는 것이다. 왜냐하면 특정 페이지의 이벤트 리스너를 해제시켜주지 않았기 때문이다.**
- docs에서는 이런 해결법을 제시한다.
```typescript
useEffect(()=>{
  if (editor === null) return:
  const cleanUpFunc = store.listen(/*blabla*/)
  return ()=>{
    store.listen(cleanUpFunc)
  }
},[editor]
```
- store.listen은 () => void func를 리턴한다.
- cleanup시 빈 껍데기 펑크션을 넣어 클린업하는 방식
- 이게 tldraw 메인테이너한테도 질문했는데, 굳이 클린업을 안하면 여러 이벤트 리스너를 등록가능한것 같은데 저런식이면 이벤트 리스너 중복 등록이 안되는 것 같음
- 따라서 한 페이지만 보냄, 호스트 소켓 통신에 걸린 `store.listen` 도 동작 안하는 것으로보임
## ⏰ 마감기한 회고
- 완전히 해결하는건 멘토링이 필요할 것 같다...