### PR TITLE
feat: style panel

### DIFF
--- a/packages/front-end/PaintPDF/components/Painter/Painter.css
+++ b/packages/front-end/PaintPDF/components/Painter/Painter.css
@@ -95,3 +95,7 @@ body {
 	--shadow-2: 0px 1px 3px hsl(0, 0%, 0%, 66.6%), 0px 2px 6px hsl(0, 0%, 0%, 33%), inset 0px 0px 0px 1px var(--color-panel-contrast);
 	--shadow-3: 0px 1px 3px hsl(0, 0%, 0%, 50%), 0px 2px 12px hsl(0, 0%, 0%, 50%), inset 0px 0px 0px 1px var(--color-panel-contrast);
 }
+
+.tlui-layout__top__right {
+	display: none;
+}

--- a/packages/front-end/PaintPDF/components/Painter/Painter.tsx
+++ b/packages/front-end/PaintPDF/components/Painter/Painter.tsx
@@ -18,6 +18,8 @@ import {
   useRelevantStyles,
   DefaultToolbar,
   DefaultToolbarContent,
+  BreakPointProvider,
+  DefaultMenuPanel,
 } from "tldraw";
 
 import "tldraw/tldraw.css";
@@ -53,9 +55,11 @@ const PainterComponent = ({
   const CustomStylePanel = memo((props: TLUiStylePanelProps) => {
     const styles = useRelevantStyles();
     return (
-      <DefaultStylePanel {...props}>
-        <DefaultStylePanelContent styles={styles} />
-      </DefaultStylePanel>
+      <BreakPointProvider forceMobile>
+        <DefaultStylePanel {...props}>
+
+        </DefaultStylePanel>
+      </BreakPointProvider>
     );
   });
   CustomStylePanel.displayName = "CustomStylePanel";
@@ -80,18 +84,26 @@ const PainterComponent = ({
       StylePanel: CustomStylePanel,
       PageMenu: null,
       NavigationPanel: null,
-      Toolbar: CustomToolbar,
+      Toolbar: (props) => (
+        <BreakPointProvider forceMobile>
+          <DefaultToolbar {...props} />
+        </BreakPointProvider>
+      ),
       KeyboardShortcutsDialog: null,
       QuickActions: null,
       HelperButtons: null,
       DebugPanel: null,
       DebugMenu: null,
       SharePanel: null,
-      MenuPanel: null,
+      MenuPanel: (props) => (
+        <BreakPointProvider forceMobile>
+          <DefaultMenuPanel {...props} />
+        </BreakPointProvider>
+      ),
       TopPanel: null,
       CursorChatBubble: null,
     }),
-    [CustomContextMenu, CustomStylePanel, CustomToolbar]
+    [CustomContextMenu, CustomStylePanel]
   );
 
   const keyboardShortcutsEnabledOverrides: TLUiOverrides = {


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 [#]
close #495 
## 📄 개요
- 스타일 패널 UI 처리
- 기존 UI는 좌측 상단이 stylepanel이 가려서 필기할 공간이 너무 줄어듬
- tldraw mobile UI는 toolbar 우측에 stylepanel을 선택적으로 끄고 켤 수 있음

## 🔁 변경 사항
- `<BreakPointProvider forceMobile>` 을 이용해 일부 UI에 모바일 UI 강제 적용
  - menuPanel과 toolbar에 적용
  - 메인테이너가 menuPanel에도 적용하라했는데 어디였는지는 기억이 잘 안남
- `.tlui-layout__top__right` 클래스 가리기
  - `display: none;` 적용
```typescript
<div className="tlui-layout__top__right">
							{SharePanel && <SharePanel />}
							{StylePanel && breakpoint >= PORTRAIT_BREAKPOINT.TABLET_SM && !isReadonlyMode && (
								<StylePanel />
							)}
						</div>

```
- SharePanel과 StylePanel이 영향을 받는데 SharePanel은 지금도 딱히 영향을 안주는 것 같음(무슨 기능이지?)

![image](https://github.com/user-attachments/assets/a8333459-59fa-40e8-9b64-96fe55671813)

- 이게 sharePanel인 것 같은데 우리 프로젝트와 큰 연관은 없어보임
## 📸 동작 화면 스크린샷
![image](https://github.com/user-attachments/assets/ba78bdb4-ef76-44c1-9a26-ed47d93f4d0f)

## 👀 기타 논의 사항

## ⏰ 마감기한 회고
- 마감기한에 비해 늦어졌다면 무엇이 병목이었는지, 빠르다면 무엇이 예상과 달리 쉬웠는지 등 회고